### PR TITLE
Fix: Separare flux login admin și utilizator

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -17,7 +17,7 @@
         {% else %}
             <p class="lead mb-4">Selectează o opțiune de autentificare:</p>
             <div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
-                <a href="{{ url_for('admin_login') }}" class="btn btn-primary btn-lg px-4 gap-3">Autentificare Utilizator</a>
+                <a href="{{ url_for('user_login') }}" class="btn btn-primary btn-lg px-4 gap-3">Autentificare Utilizator</a>
                 <a href="{{ url_for('admin_login') }}" class="btn btn-outline-secondary btn-lg px-4">Autentificare Admin</a>
             </div>
         {% endif %}

--- a/templates/user_login.html
+++ b/templates/user_login.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block title %}Autentificare Utilizator{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-6 col-lg-4">
+        <h2 class="text-center mb-4">Autentificare Utilizator</h2>
+        <div class="card">
+            <div class="card-body">
+                <form method="POST" action="{{ url_for('user_login') }}">
+                    <div class="mb-3">
+                        <label for="login_code" class="form-label">Cod Unic / Cod Personal:</label>
+                        <input type="text" class="form-control" id="login_code" name="login_code" required>
+                        <div id="codeHelp" class="form-text">Introduceți codul unic primit de la administrator (dacă este prima autentificare) sau codul personal setat anterior.</div>
+                    </div>
+                    <div class="d-grid">
+                        <button type="submit" class="btn btn-primary">Autentificare</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+        <p class="text-center mt-3">
+            <a href="{{ url_for('home') }}">Înapoi la pagina principală</a>
+        </p>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
- Adăugat rută și template dedicate pentru login utilizator (/user_login, user_login.html).
- Adăugat rută și template pentru setarea/resetarea codului personal (/set_personal_code, set_personal_code.html).
- Corectat link-ul de login utilizator în pagina principală.
- Actualizat login_manager.login_view pentru a oferi opțiuni la accesarea resurselor protejate neautentificat.
- Asigurat compatibilitatea cu funcționalitățile existente de creare și resetare utilizator de către admin.