### PR TITLE
Fix: Implement User and Admin Login Functionality

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -50,7 +50,7 @@
                         </li>
                     {% else %}
                         <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('admin_login') }}">Autentificare Utilizator</a>
+                        <a class="nav-link" href="{{ url_for('user_login') }}">Autentificare Utilizator</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('admin_login') }}">Autentificare Admin</a>


### PR DESCRIPTION
- Corrected `url_for` in `base.html` to use `user_login` for the user authentication link.
- Added `user_login` route to handle login via unique code (first time) and personal code (subsequent times).
- Added `admin_login` route for admin authentication via username/password.
- Added `logout` route.
- Added `set_personal_code` route for users to set their personal code after initial login.
- Updated `login_manager.login_view` to `user_login`.
- Ensured corresponding HTML templates (`user_login.html`, `admin_login.html`, `set_personal_code.html`) are used by these routes.

This resolves the BuildError caused by missing login routes and establishes the core authentication flow.