### PR TITLE
Fix: Correct routing errors in templates and investigate student actions

### DIFF
--- a/templates/list_daily_leaves.html
+++ b/templates/list_daily_leaves.html
@@ -6,7 +6,7 @@
 <div class="container mt-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2>Listă Învoiri Zilnice (Luni-Joi)</h2>
-        <a href="{{ url_for('add_daily_leave') }}" class="btn btn-success">
+        <a href="{{ url_for('add_edit_daily_leave') }}" class="btn btn-success">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-calendar2-plus-fill" viewBox="0 0 16 16">
                 <path d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM2 3.5v1c0 .276.244.5.545.5h10.91c.3 0 .545-.224.545-.5v-1c0-.276-.244-.5-.546-.5H2.545c-.3 0-.545.224-.545.5zm6.5 5a.5.5 0 0 0-1 0V10H6.5a.5.5 0 0 0 0 1H8v1.5a.5.5 0 0 0 1 0V11h1.5a.5.5 0 0 0 0-1H9V8.5z"/>
             </svg>
@@ -132,7 +132,7 @@
         {{ render_daily_leaves_table(past_leaves, 'Învoiri Trecute/Anulate') }}
     {% else %}
         <div class="alert alert-info mt-4" role="alert">
-            Nu există învoiri zilnice de afișat. Puteți adăuga o <a href="{{ url_for('add_daily_leave') }}" class="alert-link">învoire nouă aici</a> sau procesa o <a href="#leave_list_text" class="alert-link">listă din text</a>.
+            Nu există învoiri zilnice de afișat. Puteți adăuga o <a href="{{ url_for('add_edit_daily_leave') }}" class="alert-link">învoire nouă aici</a> sau procesa o <a href="#leave_list_text" class="alert-link">listă din text</a>.
         </div>
     {% endif %}
 

--- a/templates/list_permissions.html
+++ b/templates/list_permissions.html
@@ -6,7 +6,7 @@
 <div class="container mt-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2>Listă Permisii</h2>
-        <a href="{{ url_for('add_permission') }}" class="btn btn-success">
+        <a href="{{ url_for('add_edit_permission') }}" class="btn btn-success">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-calendar-plus-fill" viewBox="0 0 16 16">
                 <path d="M4 .5a.5.5 0 0 0-1 0V1H2a2 2 0 0 0-2 2v1h16V3a2 2 0 0 0-2-2h-1V.5a.5.5 0 0 0-1 0V1H4V.5zM16 14V5H0v9a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2zM8.5 8.5V10H10a.5.5 0 0 1 0 1H8.5v1.5a.5.5 0 0 1-1 0V11H6a.5.5 0 0 1 0-1h1.5V8.5a.5.5 0 0 1 1 0z"/>
             </svg>
@@ -90,7 +90,7 @@
         {{ render_permissions_table(past_permissions, 'Permisii Trecute/Anulate', 'past-permissions') }}
     {% else %}
         <div class="alert alert-info mt-4" role="alert">
-            Nu există permisii de afișat. Puteți adăuga o <a href="{{ url_for('add_permission') }}" class="alert-link">permisie nouă aici</a>.
+            Nu există permisii de afișat. Puteți adăuga o <a href="{{ url_for('add_edit_permission') }}" class="alert-link">permisie nouă aici</a>.
         </div>
     {% endif %}
 

--- a/templates/list_weekend_leaves.html
+++ b/templates/list_weekend_leaves.html
@@ -6,7 +6,7 @@
 <div class="container mt-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2>Listă Învoiri Weekend (Vineri-Duminică)</h2>
-        <a href="{{ url_for('add_weekend_leave') }}" class="btn btn-success">
+        <a href="{{ url_for('add_edit_weekend_leave') }}" class="btn btn-success">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-calendar-week-fill" viewBox="0 0 16 16">
                 <path d="M4 .5a.5.5 0 0 0-1 0V1H2a2 2 0 0 0-2 2v1h16V3a2 2 0 0 0-2-2h-1V.5a.5.5 0 0 0-1 0V1H4V.5zM16 14V5H0v9a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2zM9.5 7.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5zm3 0h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5zM2 10.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm3.5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5z"/>
             </svg>
@@ -101,7 +101,7 @@
         {{ render_weekend_leaves_table(past_leaves, 'Învoiri de Weekend Trecute/Anulate') }}
     {% else %}
         <div class="alert alert-info mt-4" role="alert">
-            Nu există învoiri de weekend de afișat. Puteți adăuga o <a href="{{ url_for('add_weekend_leave') }}" class="alert-link">învoire nouă aici</a>.
+            Nu există învoiri de weekend de afișat. Puteți adăuga o <a href="{{ url_for('add_edit_weekend_leave') }}" class="alert-link">învoire nouă aici</a>.
         </div>
     {% endif %}
 


### PR DESCRIPTION
- Corrected `url_for` calls in `list_permissions.html`, `list_daily_leaves.html`, and `list_weekend_leaves.html` to use the proper 'add_edit_*' endpoints, resolving BuildErrors.
- Verified other template files for similar routing issues; no further critical errors found.
- Investigated missing student actions on `list_students.html` for the 'gradat' role. The template logic appears correct; actions should be displayed if student data is rendered. The issue may be data-related or environmental if it persists.