### PR TITLE
Add role-specific Word exports and uncomment startup DB init

### DIFF
--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -94,10 +94,10 @@
 
                     <hr class="my-3">
                     <h6 class="text-muted">Rapoarte Generale Word:</h6>
-                    <a href="{{ url_for('export_permissions_scoped_word') }}" class="btn btn-sm btn-outline-primary mb-2" title="Exportă toate permisiile active/viitoare din sistem">
+                    <a href="{{ url_for('admin_export_permissions_word') }}" class="btn btn-sm btn-outline-primary mb-2" title="Exportă toate permisiile active/viitoare din sistem">
                         <i class="fas fa-file-word icon-rotate-hover"></i> Export Permisii (Toate)
                     </a>
-                    <a href="{{ url_for('export_weekend_leaves_scoped_word') }}" class="btn btn-sm btn-outline-primary mb-2" title="Exportă toate învoirile de weekend active/viitoare din sistem">
+                    <a href="{{ url_for('admin_export_weekend_leaves_word') }}" class="btn btn-sm btn-outline-primary mb-2" title="Exportă toate învoirile de weekend active/viitoare din sistem">
                         <i class="fas fa-file-word icon-rotate-hover"></i> Export Învoiri Weekend (Toate)
                     </a>
                     <!-- Alte link-uri admin pot fi adăugate aici -->

--- a/templates/battalion_commander_dashboard.html
+++ b/templates/battalion_commander_dashboard.html
@@ -27,10 +27,10 @@
     <div class="d-flex justify-content-between align-items-center">
         <h2 class="mb-3">Panou Comandant Batalionul {{ battalion_id }}</h2>
         <div class="d-flex align-items-center">
-            <a href="{{ url_for('export_permissions_scoped_word') }}" class="btn btn-sm btn-outline-primary me-2" title="Exportă raportul de permisii active/viitoare pentru batalion">
+            <a href="{{ url_for('battalion_commander_export_permissions_word') }}" class="btn btn-sm btn-outline-primary me-2" title="Exportă raportul de permisii active/viitoare pentru batalion">
                 <i class="fas fa-file-word icon-rotate-hover"></i> Export Permisii
             </a>
-            <a href="{{ url_for('export_weekend_leaves_scoped_word') }}" class="btn btn-sm btn-outline-primary me-2" title="Exportă raportul de învoiri de weekend active/viitoare pentru batalion">
+            <a href="{{ url_for('battalion_commander_export_weekend_leaves_word') }}" class="btn btn-sm btn-outline-primary me-2" title="Exportă raportul de învoiri de weekend active/viitoare pentru batalion">
                 <i class="fas fa-file-word icon-rotate-hover"></i> Export Învoiri Wk.
             </a>
             <a href="{{ url_for('battalion_commander_logs') }}" class="btn btn-sm btn-outline-info me-2" title="Vezi jurnalul de acțiuni pentru batalionul tău">

--- a/templates/company_commander_dashboard.html
+++ b/templates/company_commander_dashboard.html
@@ -27,10 +27,10 @@
     <div class="d-flex justify-content-between align-items-center">
         <h2 class="mb-3">Panou Comandant Compania {{ company_id }}</h2>
         <div class="d-flex align-items-center">
-            <a href="{{ url_for('export_permissions_scoped_word') }}" class="btn btn-sm btn-outline-primary me-2" title="Exportă raportul de permisii active/viitoare pentru companie">
+            <a href="{{ url_for('company_commander_export_permissions_word') }}" class="btn btn-sm btn-outline-primary me-2" title="Exportă raportul de permisii active/viitoare pentru companie">
                 <i class="fas fa-file-word icon-rotate-hover"></i> Export Permisii
             </a>
-            <a href="{{ url_for('export_weekend_leaves_scoped_word') }}" class="btn btn-sm btn-outline-primary me-2" title="Exportă raportul de învoiri de weekend active/viitoare pentru companie">
+            <a href="{{ url_for('company_commander_export_weekend_leaves_word') }}" class="btn btn-sm btn-outline-primary me-2" title="Exportă raportul de învoiri de weekend active/viitoare pentru companie">
                 <i class="fas fa-file-word icon-rotate-hover"></i> Export Învoiri Wk.
             </a>
             <a href="{{ url_for('company_commander_logs') }}" class="btn btn-sm btn-outline-info me-2" title="Vezi jurnalul de acțiuni pentru compania ta">


### PR DESCRIPTION
Implemented Word export functionality for Permissions and Weekend Leaves tailored for Admin, Company Commander, and Battalion Commander roles.
- Created new Flask routes and functions for each role to ensure correct data scoping.
- Updated admin, company commander, and battalion commander dashboard templates to use these new role-specific export endpoints.

Additionally, uncommented the database initialization and migration section within the `if __name__ == '__main__':` block in `app.py`. This will attempt to run these operations when `app.py` is executed directly.