### PR TITLE
Fix: Resolve TemplateNotFound errors and improve table dark theme

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -187,7 +187,52 @@ body.dark-mode .card-header {
     border-bottom: 1px solid var(--border-color);
     color: var(--text-primary); /* Ensure header text is also correct */
 }
+
+/* === START JULES' MODIFICATIONS FOR DARK MODE TABLE STYLING === */
+body.dark-mode .table th,
+body.dark-mode .table td {
+    /* color: var(--text-primary); */ /* This is already set a bit lower, will be inherited or re-asserted */
+    background-color: transparent !important; /* Remove individual cell backgrounds */
+    /* border-color: var(--border-color); */ /* Will be inherited or re-asserted by general table styles */
+}
+
 body.dark-mode .table thead th {
+    background-color: var(--bg-surface-hover) !important; /* Keep header distinct but ensure it's one of the dark theme's neutral colors */
+    /* color: var(--text-primary); */ /* Already set */
+    border-bottom-width: 2px; /* Keep header border distinct */
+}
+
+/* Neutralize specific hover and striped effects if they interfere */
+body.dark-mode .table-striped > tbody > tr:nth-of-type(odd) > * {
+    background-color: transparent !important;
+}
+body.dark-mode .table-hover > tbody > tr:hover > * {
+    background-color: rgba(255, 255, 255, 0.05) !important; /* Very subtle light hover */
+}
+
+/* Neutralize contextual backgrounds like .table-success, .table-warning etc. for ALL tables in dark mode */
+body.dark-mode .table-success > td, body.dark-mode .table-success > th,
+body.dark-mode .table-warning > td, body.dark-mode .table-warning > th,
+body.dark-mode .table-danger > td, body.dark-mode .table-danger > th,
+body.dark-mode .table-info > td, body.dark-mode .table-info > th,
+body.dark-mode .table-active > td, body.dark-mode .table-active > th,
+body.dark-mode .table-secondary > td, body.dark-mode .table-secondary > th,
+body.dark-mode .table-light > td, body.dark-mode .table-light > th,
+body.dark-mode .table-dark > td, body.dark-mode .table-dark > th {
+    background-color: transparent !important;
+    color: var(--text-primary) !important; /* Ensure text remains light */
+}
+
+/* Ensure links within these neutralized tables are also styled for dark mode */
+body.dark-mode .table a {
+    color: var(--link-color); /* Use the dark mode link color */
+}
+body.dark-mode .table a:hover {
+    color: var(--link-hover-color);
+}
+/* === END JULES' MODIFICATIONS FOR DARK MODE TABLE STYLING === */
+
+body.dark-mode .table thead th { /* This rule was already present, ensure it's not conflicting or duplicate if my additions are above */
     background-color: var(--bg-surface-hover);
     border-bottom: 2px solid var(--border-color);
     color: var(--text-primary); /* Ensure table header text is correct */

--- a/templates/scoped_list_permissions.html
+++ b/templates/scoped_list_permissions.html
@@ -1,0 +1,127 @@
+{% extends "base.html" %}
+
+{% block title %}Listă Permisii - {{ current_user.username }}{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h2 class="mb-0">Listă Permisii</h2> <!-- mb-0 for alignment -->
+        <div class="d-flex align-items-center">
+            <a href="{{ url_for('gradat_page_import_permissions') }}" class="btn btn-info btn-sm me-2" title="Importă mai multe permisii dintr-un text copiat">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-upload me-1 icon-rotate-hover" viewBox="0 0 16 16">
+                    <path d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z"/>
+                    <path d="M7.646 1.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 2.707V11.5a.5.5 0 0 1-1 0V2.707L5.354 4.854a.5.5 0 1 1-.708-.708l3-3z"/>
+                </svg>
+                Importă Permisii (Pagină Nouă)
+            </a>
+            <a href="{{ url_for('gradat_export_permissions_word') }}" class="btn btn-outline-primary btn-sm me-2" title="Exportă permisiile active/viitoare în format Word">
+                <i class="fas fa-file-word icon-rotate-hover"></i> Exportă (Word)
+            </a>
+            <a href="{{ url_for('add_edit_permission') }}" class="btn btn-success btn-sm me-2" title="Adaugă o permisie individuală">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-calendar-plus-fill me-1 icon-rotate-hover" viewBox="0 0 16 16">
+                    <path d="M4 .5a.5.5 0 0 0-1 0V1H2a2 2 0 0 0-2 2v1h16V3a2 2 0 0 0-2-2h-1V.5a.5.5 0 0 0-1 0V1H4V.5zM16 14V5H0v9a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2zM8.5 8.5V10H10a.5.5 0 0 1 0 1H8.5v1.5a.5.5 0 0 1-1 0V11H6a.5.5 0 0 1 0-1h1.5V8.5a.5.5 0 0 1 1 0z"/>
+                </svg>
+                Adaugă Nouă
+            </a>
+            <a href="{{ url_for('gradat_bulk_add_permission') }}" class="btn btn-warning btn-sm me-2" title="Adaugă aceeași permisie pentru mai mulți studenți simultan">
+                <i class="fas fa-users-cog icon-rotate-hover"></i> Adaugă Multiplu
+            </a>
+            <a href="{{ url_for('dashboard') }}" class="btn btn-outline-secondary btn-sm">&laquo; Panou Gradat</a>
+        </div>
+    </div>
+
+    {% macro render_permissions_table(permissions, table_title, table_id) %}
+        {% if permissions %}
+        <h4 class="mt-4">{{ table_title }} ({{ permissions|length }})</h4>
+        <div class="table-responsive shadow-sm"> <!-- Added shadow-sm -->
+            <table class="table table-striped table-hover table-sm">
+                <thead> <!-- Am eliminat clasa table-dark -->
+                    <tr>
+                        <th>Student</th>
+                        <th>Grad</th>
+                        <th>De la</th>
+                        <th>Până la</th>
+                        <th>Destinație</th>
+                        <th>Transport</th>
+                        <th>Motiv/Obs.</th>
+                        <th>Status</th>
+                        <th>Acțiuni</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for p in permissions %}
+                    <tr class="{{ 'table-success' if p.is_active else ('table-warning' if p.is_upcoming else 'table-secondary') }}">
+                        <td>{{ p.student.nume }} {{ p.student.prenume }}</td>
+                        <td>{{ p.student.grad_militar }}</td>
+                        <td>{{ p.start_datetime|localdatetime('%d-%m-%Y %H:%M') }}</td>
+                        <td>{{ p.end_datetime|localdatetime('%d-%m-%Y %H:%M') }}</td>
+                        <td>{{ p.destination if p.destination else '-' }}</td>
+                        <td>{{ p.transport_mode if p.transport_mode else '-' }}</td>
+                        <td>{{ p.reason if p.reason else '-' }}</td>
+                        <td>
+                            {% if p.status == 'Aprobată' %}
+                                {% if p.is_active %}
+                                    <span class="badge bg-success">Activă</span>
+                                {% elif p.is_upcoming %}
+                                    <span class="badge bg-warning text-dark">Urmează</span>
+                                {% else %}
+                                    <span class="badge bg-secondary">Expirată</span>
+                                {% endif %}
+                            {% elif p.status == 'Anulată' %}
+                                <span class="badge bg-danger">Anulată</span>
+                            {% else %}
+                                <span class="badge bg-light text-dark">{{ p.status }}</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <a href="{{ url_for('add_edit_permission', permission_id=p.id) }}" class="btn btn-sm btn-warning me-1 py-0 px-1" title="Editare Permisie">
+                                <i class="fas fa-edit icon-rotate-hover"></i>
+                            </a>
+                            {% if p.status == 'Aprobată' and (p.is_active or p.is_upcoming) %}
+                            <form method="POST" action="{{ url_for('cancel_permission', permission_id=p.id) }}" class="d-inline" onsubmit="return confirm('Ești sigur că vrei să anulezi această permisie?');">
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" title="Anulează Permisia">
+                                    <i class="fas fa-times-circle icon-rotate-hover"></i>
+                                </button>
+                            </form>
+                            {% elif p.status != 'Anulată' and p.is_past %}
+                                <span class="text-muted fst-italic small">Expirată</span>
+                            {% elif p.status == 'Anulată' %}
+                                <span class="text-muted fst-italic small">Anulată</span>
+                            {% endif %}
+                            {# Buton de ștergere permanentă, vizibil mereu, dar poate condiționat de rol dacă e necesar #}
+                            <form method="POST" action="{{ url_for('delete_permission', permission_id=p.id) }}" class="d-inline" onsubmit="return confirm('Ești sigur că vrei să ȘTERGI PERMANENT această permisie? Această acțiune nu poate fi anulată.');">
+                                <button type="submit" class="btn btn-sm btn-danger py-0 px-1 ms-1" title="Șterge Permisia Permanent">
+                                    <i class="fas fa-trash-alt icon-rotate-hover"></i>
+                                </button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {# Am eliminat clauza else pentru a gestiona mesajul global #}
+        {% endif %}
+    {% endmacro %}
+
+    {% if active_permissions or upcoming_permissions or past_permissions %}
+        {{ render_permissions_table(active_permissions, 'Permisii Active Acum', 'active-permissions') }}
+        {{ render_permissions_table(upcoming_permissions, 'Permisii Viitoare', 'upcoming-permissions') }}
+        {{ render_permissions_table(past_permissions, 'Permisii Trecute/Anulate', 'past-permissions') }}
+    {% else %}
+        <div class="alert alert-info mt-4" role="alert">
+            Nu există permisii de afișat. Puteți adăuga o <a href="{{ url_for('add_edit_permission') }}" class="alert-link">permisie nouă aici</a>.
+        </div>
+    {% endif %}
+
+    <p class="mt-4">
+        <a href="{{ url_for('dashboard') }}" class="btn btn-outline-secondary btn-sm">
+            &laquo; Înapoi la Panoul Gradat
+        </a>
+    </p>
+</div>
+
+{# Modalul pentru Bulk Import Permisii a fost eliminat. Funcționalitatea este acum pe o pagină separată. #}
+{# Se poate șterge acest comentariu și tot conținutul modalului dacă nu mai este necesar ca referință. #}
+
+{% endblock %}

--- a/templates/scoped_list_weekend_leaves.html
+++ b/templates/scoped_list_weekend_leaves.html
@@ -1,0 +1,139 @@
+{% extends "base.html" %}
+
+{% block title %}Listă Învoiri Weekend - {{ current_user.username }}{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h2 class="mb-0">Listă Învoiri Weekend (Vineri-Duminică)</h2> <!-- mb-0 for alignment -->
+        <div class="d-flex align-items-center">
+            <a href="{{ url_for('gradat_page_import_weekend_leaves') }}" class="btn btn-info btn-sm me-2" title="Importă mai multe învoiri de weekend dintr-un text copiat">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-upload me-1 icon-rotate-hover" viewBox="0 0 16 16">
+                    <path d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z"/>
+                    <path d="M7.646 1.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 2.707V11.5a.5.5 0 0 1-1 0V2.707L5.354 4.854a.5.5 0 1 1-.708-.708l3-3z"/>
+                </svg>
+                Importă Învoiri Weekend (Pagină Nouă)
+            </a>
+            <a href="{{ url_for('gradat_export_weekend_leaves_word') }}" class="btn btn-outline-primary btn-sm me-2" title="Exportă învoirile de weekend active/viitoare în format Word">
+                <i class="fas fa-file-word icon-rotate-hover"></i> Exportă (Word)
+            </a>
+            <a href="{{ url_for('add_edit_weekend_leave') }}" class="btn btn-success btn-sm me-2" title="Adaugă o învoire de weekend individuală">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-calendar-week-fill me-1 icon-rotate-hover" viewBox="0 0 16 16">
+                    <path d="M4 .5a.5.5 0 0 0-1 0V1H2a2 2 0 0 0-2 2v1h16V3a2 2 0 0 0-2-2h-1V.5a.5.5 0 0 0-1 0V1H4V.5zM16 14V5H0v9a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2zM9.5 7.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5zm3 0h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5zM2 10.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm3.5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5z"/>
+                </svg>
+                Adaugă Nouă
+            </a>
+            <a href="{{ url_for('gradat_bulk_add_weekend_leave') }}" class="btn btn-warning btn-sm me-2" title="Adaugă aceeași învoire de weekend pentru mai mulți studenți simultan">
+                <i class="fas fa-users-cog icon-rotate-hover"></i> Adaugă Multiplu
+            </a>
+            <a href="{{ url_for('dashboard') }}" class="btn btn-outline-secondary btn-sm">&laquo; Panou Gradat</a>
+        </div>
+    </div>
+
+    {% macro render_weekend_leaves_table(leaves, table_title) %}
+        {% if leaves %}
+        <h4 class="mt-4">{{ table_title }} ({{ leaves|length }})</h4>
+        <div class="table-responsive shadow-sm"> <!-- Added shadow-sm -->
+            <table class="table table-striped table-hover table-sm">
+                <thead> <!-- Am eliminat clasa table-dark -->
+                    <tr>
+                        <th>Student</th>
+                        <th>Weekend (Vineri)</th>
+                        <th>Zile și Intervale Selectate</th>
+                        <th>Motiv</th>
+                        <th>Status</th>
+                        <th>Acțiuni</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for leave in leaves %}
+                    <tr class="{{ 'table-success' if leave.is_any_interval_active_now and leave.status == 'Aprobată' else ('table-warning' if leave.is_overall_active_or_upcoming else 'table-secondary') }}">
+                        <td>{{ leave.student.nume }} {{ leave.student.prenume }}</td>
+                        <td>{{ leave.weekend_start_date|localdate('%d-%m-%y') }}</td>
+                        <td>
+                            {% for interval in leave.get_intervals() %}
+                                <div>
+                                    <strong>{{ interval.day_name }}</strong> ({{ interval.start|localdatetime('%d-%m') }}):
+                                    {{ interval.start|localdatetime('%H:%M') }} - {{ interval.end|localdatetime('%H:%M') }}
+                                    {% if interval.is_active_now and leave.status == 'Aprobată' %} {# is_active_now in interval nu există, e pe leave #}
+                                        {# Verificarea de 'Activ acum' se bazează pe leave.is_any_interval_active_now și intervalul curent #}
+                                        {# Pentru simplificare, vom lăsa cum era, dar corect ar fi să verificăm intervalul curent vs now #}
+                                        {# Presupunând că `interval` are `start` și `end` ca datetime-uri deja localizate sau naive corecte #}
+                                        {% set now_interval_check = get_localized_now() %} {# Necesar dacă interval.start/end sunt naive #}
+                                        {% if interval.start <= now_interval_check <= interval.end %}
+                                        <span class="badge bg-success ms-1">Activ acum</span>
+                                        {% endif %}
+                                    {% endif %}
+                                </div>
+                            {% else %}
+                                Nespecificat
+                            {% endfor %}
+                        </td>
+                        <td>{{ leave.reason if leave.reason else '-' }}</td>
+                        <td>
+                            {% if leave.status == 'Aprobată' %}
+                                {% if leave.is_overall_past %}
+                                    <span class="badge bg-secondary">Expirată</span>
+                                {% elif leave.is_any_interval_active_now %}
+                                     <span class="badge bg-success">Cel puțin un interval Activ</span>
+                                {% elif leave.is_overall_active_or_upcoming %}
+                                    <span class="badge bg-warning text-dark">Urmează</span>
+                                {% else %}
+                                     <span class="badge bg-info text-dark">Aprobată</span> {# Fallback if logic is tricky #}
+                                {% endif %}
+                            {% elif leave.status == 'Anulată' %}
+                                <span class="badge bg-danger">Anulată</span>
+                            {% else %}
+                                <span class="badge bg-light text-dark">{{ leave.status }}</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <a href="{{ url_for('add_edit_weekend_leave', leave_id=leave.id) }}" class="btn btn-sm btn-warning me-1 py-0 px-1" title="Editare Învoire Weekend">
+                                <i class="fas fa-edit icon-rotate-hover"></i>
+                            </a>
+                            {% if leave.status == 'Aprobată' and leave.is_overall_active_or_upcoming %}
+                            <form method="POST" action="{{ url_for('cancel_weekend_leave', leave_id=leave.id) }}" class="d-inline" onsubmit="return confirm('Ești sigur că vrei să anulezi această învoire de weekend?');">
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" title="Anulează Învoirea">
+                                     <i class="fas fa-times-circle icon-rotate-hover"></i>
+                                </button>
+                            </form>
+                            {% elif leave.status != 'Anulată' and leave.is_overall_past %}
+                                <span class="text-muted fst-italic small">Expirată</span>
+                            {% elif leave.status == 'Anulată' %}
+                                <span class="text-muted fst-italic small">Anulată</span>
+                            {% endif %}
+                            {# Buton de ștergere permanentă #}
+                            <form method="POST" action="{{ url_for('delete_weekend_leave', leave_id=leave.id) }}" class="d-inline" onsubmit="return confirm('Ești sigur că vrei să ȘTERGI PERMANENT această învoire de weekend? Această acțiune nu poate fi anulată.');">
+                                <button type="submit" class="btn btn-sm btn-danger py-0 px-1 ms-1" title="Șterge Învoirea de Weekend Permanent">
+                                    <i class="fas fa-trash-alt icon-rotate-hover"></i>
+                                </button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {# Am eliminat clauza else pentru a gestiona mesajul global #}
+        {% endif %}
+    {% endmacro %}
+
+    {% if active_or_upcoming_leaves or past_leaves %}
+        {{ render_weekend_leaves_table(active_or_upcoming_leaves, 'Învoiri de Weekend Active sau Viitoare') }}
+        {{ render_weekend_leaves_table(past_leaves, 'Învoiri de Weekend Trecute/Anulate') }}
+    {% else %}
+        <div class="alert alert-info mt-4" role="alert">
+            Nu există învoiri de weekend de afișat. Puteți adăuga o <a href="{{ url_for('add_edit_weekend_leave') }}" class="alert-link">învoire nouă aici</a>.
+        </div>
+    {% endif %}
+
+    <p class="mt-4">
+        <a href="{{ url_for('dashboard') }}" class="btn btn-outline-secondary btn-sm">
+            &laquo; Înapoi la Panoul Gradat
+        </a>
+    </p>
+</div>
+
+{# Modalul pentru Bulk Import Învoiri Weekend a fost eliminat. Funcționalitatea este acum pe o pagină separată. #}
+
+{% endblock %}


### PR DESCRIPTION
- Created missing template files `scoped_list_permissions.html` and `scoped_list_weekend_leaves.html` by copying their respective non-scoped versions. This fixes `TemplateNotFound` errors when accessing company/battalion commander permission/leave views.

- Updated `static/css/style.css` to address dark theme issues in tables:
  - Set table cell (td, th) backgrounds to transparent in dark mode.
  - Neutralized contextual backgrounds (e.g., .table-success) in dark mode.
  - Ensured text in tables is light-colored (var(--text-primary)) in dark mode.
  - Table headers retain a neutral dark background (var(--bg-surface-hover)).
  - Adjusted table striping and hover effects for dark mode.

- Performed a general check and confirmed no other active `render_template` calls point to missing template files.