### PR TITLE
Fix: Resolve dashboard BuildError and other routing issues

### DIFF
--- a/app.py
+++ b/app.py
@@ -2537,7 +2537,8 @@ def gradat_page_import_permissions():
     if current_user.role != 'gradat':
         flash('Acces neautorizat.', 'danger')
         return redirect(url_for('dashboard'))
-    return render_template('gradat_import_permissions_page.html', title="Import Masiv Permisii din Text")
+    # Corrected template filename
+    return render_template('gradat_import_permissions.html', title="Import Masiv Permisii din Text")
 
 @app.route('/gradat/weekend_leaves/import_page', methods=['GET'], endpoint='gradat_page_import_weekend_leaves')
 @login_required
@@ -2545,7 +2546,8 @@ def gradat_page_import_weekend_leaves():
     if current_user.role != 'gradat':
         flash('Acces neautorizat.', 'danger')
         return redirect(url_for('dashboard'))
-    return render_template('gradat_import_weekend_leaves_page.html', title="Import Masiv Învoiri Weekend din Text")
+    # Corrected template filename
+    return render_template('gradat_import_weekend_leaves.html', title="Import Masiv Învoiri Weekend din Text")
 
 @app.route('/commander/presence_report_data', methods=['GET'])
 @login_required
@@ -2630,6 +2632,24 @@ def admin_change_self_password():
             db.session.commit() 
             return redirect(url_for('admin_change_self_password'))
     return render_template('admin_change_password.html')
+
+@app.route('/dashboard')
+@login_required
+def dashboard():
+    if current_user.role == 'admin':
+        return redirect(url_for('admin_dashboard_route'))
+    elif current_user.role == 'gradat':
+        # Redirecting to gradat_dashboard_route which renders situatie_pluton.html
+        return redirect(url_for('gradat_dashboard_route'))
+    elif current_user.role == 'comandant_companie':
+        return redirect(url_for('company_commander_dashboard'))
+    elif current_user.role == 'comandant_batalion':
+        return redirect(url_for('battalion_commander_dashboard'))
+    else:
+        # Fallback, though ideally all authenticated users have a role
+        # that directs them to a specific dashboard.
+        flash('Rol utilizator necunoscut sau neconfigurat pentru dashboard.', 'warning')
+        return redirect(url_for('home'))
 
 @app.route('/admin/user/<int:user_id>/set_personal_code', methods=['GET', 'POST'], endpoint='admin_set_user_personal_code')
 @login_required

--- a/templates/admin_action_logs.html
+++ b/templates/admin_action_logs.html
@@ -144,11 +144,10 @@
                     {% else %}
                         <li class="page-item"><a class="page-link" href="{{ url_for('admin_action_logs', page=page_num, **request.args) }}">{{ page_num }}</a></li>
                     {% endif %}
-                {% elif loop.index0 == 0 or loop.index0 == list(logs_pagination.iter_pages(left_edge=1, right_edge=1, left_current=2, right_current=3))|length -1 %}
-                    {# Ellipsis only if not at the very start/end of all possible iter_pages items #}
-                    {# Converted iter_pages to list before applying length filter to fix TypeError - Jules #}
                 {% else %}
-                     <li class="page-item disabled"><span class="page-link">...</span></li>
+                    {% if loop.previtem is number and loop.nextitem is number %} {# More robust ellipsis check #}
+                        <li class="page-item disabled"><span class="page-link">...</span></li>
+                    {% endif %}
                 {% endif %}
             {% endfor %}
 

--- a/templates/commander_action_logs.html
+++ b/templates/commander_action_logs.html
@@ -147,10 +147,10 @@
                     {% else %}
                         <li class="page-item"><a class="page-link" href="{{ url_for(request.endpoint, page=page_num, **request.args) }}">{{ page_num }}</a></li>
                     {% endif %}
-                {% elif loop.index0 == 0 or loop.index0 == list(logs_pagination.iter_pages(left_edge=1, right_edge=1, left_current=2, right_current=3))|length -1 %}
-                    {# Converted iter_pages to list before applying length filter to fix TypeError - Jules #}
                 {% else %}
-                     <li class="page-item disabled"><span class="page-link">...</span></li>
+                    {% if loop.previtem is number and loop.nextitem is number %} {# More robust ellipsis check #}
+                        <li class="page-item disabled"><span class="page-link">...</span></li>
+                    {% endif %}
                 {% endif %}
             {% endfor %}
 

--- a/templates/gradat_import_permissions.html
+++ b/templates/gradat_import_permissions.html
@@ -33,7 +33,7 @@ Vizită familie</code></pre>
 
             <hr class="my-4">
 
-            <form method="POST" action="{{ url_for('gradat_page_import_permissions') }}">
+            <form method="POST" action="{{ url_for('gradat_bulk_import_permissions') }}">
                 <div class="mb-3">
                     <label for="permission_bulk_data" class="form-label">Date Permisii (copiați textul aici):</label>
                     <textarea class="form-control" id="permission_bulk_data" name="permission_bulk_data" rows="15" required placeholder="Introduceți datele conform formatului de mai sus..."></textarea>

--- a/templates/gradat_import_weekend_leaves.html
+++ b/templates/gradat_import_weekend_leaves.html
@@ -30,7 +30,7 @@ Cap. Ionescu Ana, 02.08.2024 18:00-22:00</code></pre>
 
             <hr class="my-4">
 
-            <form method="POST" action="{{ url_for('gradat_page_import_weekend_leaves') }}">
+            <form method="POST" action="{{ url_for('gradat_process_weekend_leaves_text') }}">
                 <div class="mb-3">
                     <label for="weekend_leave_bulk_data" class="form-label">Date Învoiri Weekend (copiați textul aici):</label>
                     <textarea class="form-control" id="weekend_leave_bulk_data" name="weekend_leave_bulk_data" rows="15" required placeholder="Introduceți datele conform formatului de mai sus..."></textarea>


### PR DESCRIPTION
- Add a general /dashboard route to redirect users to role-specific dashboards, fixing the primary BuildError for url_for('dashboard').
- Correct pagination loop logic in admin_action_logs.html and commander_action_logs.html.
- Fix TemplateNotFound errors by correcting render_template calls for gradat import pages in app.py.
- Correct form action URLs in gradat_import_permissions.html and gradat_import_weekend_leaves.html to point to the correct processing endpoints.
- Update the /dashboard redirect for 'gradat' users to point to 'gradat_dashboard_route' (situatie_pluton.html).