### PR TITLE
Fix Undefined 'app' in Templates and Add Quick Hour Buttons

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,6 +78,11 @@ def inject_global_vars():
     # ensure this processor is correctly registered and the Flask app is restarted.
     return dict(get_localized_now=get_localized_now)
 
+@app.context_processor
+def inject_app_config():
+    # Makes the Flask app object available as 'app' in all templates
+    return dict(app=app)
+
 # IMPORTANT: Change this to a strong, unique, and static secret key in a real environment!
 # Using a static key is crucial for session persistence across app restarts.
 # For production, load from an environment variable.

--- a/templates/add_edit_daily_leave.html
+++ b/templates/add_edit_daily_leave.html
@@ -45,6 +45,15 @@
                                        value="{{ form_data.end_time or '' }}" required>
                             </div>
                         </div>
+                        <!-- Quick Hour Buttons -->
+                        <div class="mb-2">
+                          <label class="form-label">Ora Rapidă:</label>
+                          <div class="btn-group btn-group-sm">
+                            <button type="button" class="btn btn-outline-secondary quick-hour" data-hour="07:00">07:00</button>
+                            <button type="button" class="btn btn-outline-secondary quick-hour" data-hour="15:00">15:00</button>
+                            <button type="button" class="btn btn-outline-secondary quick-hour" data-hour="22:00">22:00</button>
+                          </div>
+                        </div>
                         <small class="form-text text-muted d-block mb-3">
                             Intervale permise: <strong>07:00 - 14:20</strong> (în timpul programului) sau <strong>22:00 - 07:00</strong> (în afara programului, poate trece în ziua următoare).
                         </small>
@@ -76,4 +85,16 @@
         </div>
     </div>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.querySelectorAll('.quick-hour').forEach(btn=>{
+  btn.addEventListener('click',()=>{
+    let hour=btn.dataset.hour;
+    document.getElementById('start_time').value=hour;
+    document.getElementById('end_time').value='';
+  });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
This pull request addresses the `UndefinedError: 'app' is undefined` occurring in the Jinja2 templates by adding a context processor that injects the Flask app object into the template context. Additionally, it introduces quick hour buttons in the daily leave edit form, allowing users to quickly set predefined times (07:00, 15:00, 22:00) without altering the existing hour setting functionality. Improvements are also made to ensure better user experience and code structure.

---

> This pull request was co-created with Cosine Genie

Original Task: [test/837neafek8p3](https://cosine.sh/21as2gnxjvhd/test/task/837neafek8p3)
Author: rentfrancisc
