### PR TITLE
Fix absentee display and add copy-to-clipboard feature

### DIFF
--- a/templates/battalion_commander_dashboard.html
+++ b/templates/battalion_commander_dashboard.html
@@ -201,17 +201,17 @@
             </ul>
         {% endif %}
         
-        {% if data.absent_students_details %}
+        {% if data.all_absent_details %}
             <h6 class="mt-2 mb-1">
                 Absenți Motivat ({{ data.efectiv_absent_total }})
                 <button class="btn btn-outline-info btn-sm toggle-details-btn" data-bs-toggle="collapse" data-bs-target="#{{ id_prefix }}-absent-details" aria-expanded="false" aria-controls="{{ id_prefix }}-absent-details">Detalii</button>
             </h6>
             <ul class="list-group list-group-flush collapse details-list" id="{{ id_prefix }}-absent-details">
-                {% for item in data.absent_students_details %}
+                {% for item in data.all_absent_details %}
                     <li class="list-group-item list-group-item-sm py-1">{{ item }}</li>
                 {% endfor %}
             </ul>
-        {% elif data.efectiv_absent_total == 0 and data.efectiv_control > 0 and data.efectiv_prezent_total == data.efectiv_control %}
+        {% elif data.efectiv_absent_total == 0 and data.efectiv_control > 0 %}
              <p class="text-success mt-2 mb-0"><small>Niciun student absent motivat.</small></p>
         {% endif %}
     {% endmacro %}
@@ -221,7 +221,7 @@
     <div class="card shadow-sm mb-4">
         <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
             <h4 class="mb-0">Efective Totale Batalionul {{ battalion_id }}</h4>
-            <button class="btn btn-light btn-sm copy-btn" data-target="#raport-apel-batalion">
+            <button class="btn btn-light btn-sm copy-btn" onclick="copyReportToClipboard('raport-apel-batalion')">
                 <i class="fas fa-copy"></i> Copiază
             </button>
         </div>
@@ -238,21 +238,16 @@ RAPORT OPERATIV - BATALIONUL {{ battalion_id }}
 Data și ora raportului: {{ roll_call_time_str }}
 ========================================
 SITUAȚIE CENTRALIZATOARE BATALION:
-  Efectiv control (Ec): {{ total_battalion_presence.efectiv_control }}
-  Efectiv prezent (Ep): {{ total_battalion_presence.efectiv_prezent_total }}
-    - În formație: {{ total_battalion_presence.in_formation_count }}
-    - La Servicii: {{ total_battalion_presence.on_duty_count }}
-    - Gradat Pluton (prezent): {{ total_battalion_presence.platoon_graded_duty_count }}
-  Efectiv absent (Ea): {{ total_battalion_presence.efectiv_absent_total }}
+EC: {{ total_battalion_presence.efectiv_control }}, EP: {{ total_battalion_presence.efectiv_prezent_total }}, EA: {{ total_battalion_presence.efectiv_absent_total }}
 ========================================
 {% for company_name, company_data in companies_data.items()|sort %}
 SITUAȚIE {{ company_name }}:
   Ec: {{ company_data.efectiv_control }}, Ep: {{ company_data.efectiv_prezent_total }}, Ea: {{ company_data.efectiv_absent_total }}
-    În formație: {{ company_data.in_formation_count }}
-    La Servicii: {{ company_data.on_duty_count }}
-    Gradat Pluton (prezent): {{ company_data.platoon_graded_duty_count }}
-{% if company_data.absent_students_details %}    Absenți motivat:
-{% for detail in company_data.absent_students_details %}      - {{ detail }}
+    - În formație: {{ company_data.in_formation_count }}
+    - La Servicii: {{ company_data.on_duty_count }}
+    - Gradați (prezenți): {{ company_data.platoon_graded_duty_count }}
+{% if company_data.all_absent_details %}    Absenți motivat ({{ company_data.efectiv_absent_total }}):
+{% for detail in company_data.all_absent_details %}      - {{ detail }}
 {% endfor %}{% endif %}----------------------------------------
 {% endfor %}
             </pre>
@@ -360,7 +355,42 @@ SITUAȚIE {{ company_name }}:
 
 {% block scripts %}
 {{ super() }}
-{# Scriptul pentru toggle este implicit gestionat de Bootstrap 5 Collapse, nu e nevoie de JS custom simplu. #}
-{# Asigură-te că ai Bootstrap JS inclus în base.html sau global. #}
-{# Exemplu: <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"><\/script> #}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    // Toggle details functionality is handled by Bootstrap 5 Collapse attributes
+});
+
+function copyReportToClipboard(elementId) {
+    const reportTextElement = document.getElementById(elementId);
+    if (!reportTextElement) {
+        alert('Eroare: Elementul text pentru copiere nu a fost găsit.');
+        return;
+    }
+    const reportText = reportTextElement.innerText.trim();
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(reportText).then(function() {
+            alert('Raportul a fost copiat în clipboard!');
+        }, function(err) {
+            console.error('Async: Could not copy text: ', err);
+            alert('Eroare la copierea raportului (navigator).');
+        });
+    } else {
+        const textarea = document.createElement('textarea');
+        textarea.value = reportText;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = 0;
+        document.body.appendChild(textarea);
+        textarea.select();
+        try {
+            document.execCommand('copy');
+            alert('Raportul a fost copiat în clipboard! (fallback)');
+        } catch (err) {
+            console.error('Fallback: Oops, unable to copy: ', err);
+            alert('Eroare la copierea raportului (fallback).');
+        }
+        document.body.removeChild(textarea);
+    }
+}
+</script>
 {% endblock %}

--- a/templates/company_commander_dashboard.html
+++ b/templates/company_commander_dashboard.html
@@ -205,17 +205,17 @@
             </ul>
         {% endif %}
         
-        {% if data.absent_students_details %}
+        {% if data.all_absent_details %}
             <h6 class="mt-2 mb-1">
                 Absenți Motivat ({{ data.efectiv_absent_total }})
                 <button class="btn btn-outline-info btn-sm toggle-details-btn" data-bs-toggle="collapse" data-bs-target="#{{ id_prefix }}-absent-details" aria-expanded="false" aria-controls="{{ id_prefix }}-absent-details">Detalii</button>
             </h6>
             <ul class="list-group list-group-flush collapse details-list" id="{{ id_prefix }}-absent-details">
-                {% for item in data.absent_students_details %}
+                {% for item in data.all_absent_details %}
                     <li class="list-group-item list-group-item-sm py-1">{{ item }}</li>
                 {% endfor %}
             </ul>
-        {% elif data.efectiv_absent_total == 0 and data.efectiv_control > 0 and data.efectiv_prezent_total == data.efectiv_control %}
+        {% elif data.efectiv_absent_total == 0 and data.efectiv_control > 0 %}
              <p class="text-success mt-2 mb-0"><small>Niciun student absent motivat.</small></p>
         {% endif %}
     {% endmacro %}
@@ -224,7 +224,7 @@
     <div class="card shadow-sm mb-4">
         <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center" style="background-color: var(--bs-primary) !important;">
             <h4 class="mb-0">Efective Totale Compania {{ company_id }}</h4>
-            <button class="btn btn-light btn-sm copy-btn" data-target="#raport-apel-companie">
+            <button class="btn btn-light btn-sm copy-btn" onclick="copyReportToClipboard('raport-apel-companie')">
                 <i class="fas fa-copy"></i> Copiază
             </button>
         </div>
@@ -237,19 +237,11 @@
             </p>
             {{ display_presence_details(total_company_presence, "total-company") }}
             <pre id="raport-apel-companie" class="report-text-block" style="display: none;">
-RAPORT OPERATIV - COMPANIA {{ company_id }}
-Data și ora raportului: {{ roll_call_time_str }}
-------------------------------
-Efectiv control (Ec): {{ total_company_presence.efectiv_control }}
-Efectiv prezent (Ep): {{ total_company_presence.efectiv_prezent_total }}
-  - În formație: {{ total_company_presence.in_formation_count }}
-  - La Servicii: {{ total_company_presence.on_duty_count }}
-  - Gradat Pluton (prezent): {{ total_company_presence.platoon_graded_duty_count }}
-Efectiv absent (Ea): {{ total_company_presence.efectiv_absent_total }}
-------------------------------
-{% if total_company_presence.absent_students_details %}
-ABSENȚI MOTIVAT:
-{% for detail in total_company_presence.absent_students_details %}  - {{ detail }}
+EC: {{ total_company_presence.efectiv_control }}, EP: {{ total_company_presence.efectiv_prezent_total }}, EA: {{ total_company_presence.efectiv_absent_total }}
+{% if total_company_presence.all_absent_details %}
+Absenti motivat:
+{% for detail in total_company_presence.all_absent_details %}
+- {{ detail }}
 {% endfor %}
 {% endif %}
             </pre>
@@ -362,9 +354,40 @@ ABSENȚI MOTIVAT:
 {{ super() }}
 <script>
 document.addEventListener('DOMContentLoaded', function () {
-    // Nu mai este necesar un script specific pentru toggle, deoarece Bootstrap 5 Collapse funcționează direct.
-    // Asigură-te că ai Bootstrap JS inclus în base.html sau global.
-    // Exemplu: <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"><\/script>
+    // Toggle details functionality can be handled directly by Bootstrap 5 Collapse attributes
 });
+
+function copyReportToClipboard(elementId) {
+    const reportTextElement = document.getElementById(elementId);
+    if (!reportTextElement) {
+        alert('Eroare: Elementul text pentru copiere nu a fost găsit.');
+        return;
+    }
+    const reportText = reportTextElement.innerText.trim();
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(reportText).then(function() {
+            alert('Raportul a fost copiat în clipboard!');
+        }, function(err) {
+            console.error('Async: Could not copy text: ', err);
+            alert('Eroare la copierea raportului (navigator).');
+        });
+    } else {
+        const textarea = document.createElement('textarea');
+        textarea.value = reportText;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = 0;
+        document.body.appendChild(textarea);
+        textarea.select();
+        try {
+            document.execCommand('copy');
+            alert('Raportul a fost copiat în clipboard! (fallback)');
+        } catch (err) {
+            console.error('Fallback: Oops, unable to copy: ', err);
+            alert('Eroare la copierea raportului (fallback).');
+        }
+        document.body.removeChild(textarea);
+    }
+}
 </script>
 {% endblock %}

--- a/templates/gradat_dashboard.html
+++ b/templates/gradat_dashboard.html
@@ -56,12 +56,13 @@
             </div>
         </div>
         <pre id="situatie-pluton-text" class="report-text-block" style="display: none;">
-Situație Pluton ({{ get_localized_now().strftime('%d-%m-%Y %H:%M') }})
-------------------------------
-Total Studenți: {{ sit_total_studenti }}
-Prezenți Formație: {{ sit_prezenti_formatie }}
-Total Învoiți/Absenți: {{ sit_total_invoiti_acum }}
-În Serviciu: {{ sit_in_serviciu_acum }}
+EC: {{ sit_total_studenti }}, EP: {{ sit_prezenti_formatie + sit_in_serviciu_acum + sit_gradat_pluton_prezent_acum }}, EA: {{ sit_total_invoiti_acum }}
+{% if sit_total_invoiti_acum > 0 %}
+Absenti motivat:
+{% for detail in current_platoon_situation.all_absent_details %}
+- {{ detail }}
+{% endfor %}
+{% endif %}
         </pre>
     </div>
 
@@ -144,4 +145,51 @@ Total Învoiți/Absenți: {{ sit_total_invoiti_acum }}
         </div>
     </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+function copyReportToClipboard(elementId) {
+    const reportTextElement = document.getElementById(elementId);
+    if (!reportTextElement) {
+        alert('Eroare: Elementul text pentru copiere nu a fost găsit.');
+        return;
+    }
+    const reportText = reportTextElement.innerText.trim();
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(reportText).then(function() {
+            alert('Situația a fost copiată în clipboard!');
+        }, function(err) {
+            console.error('Async: Could not copy text: ', err);
+            alert('Eroare la copierea situației (navigator).');
+        });
+    } else {
+        const textarea = document.createElement('textarea');
+        textarea.value = reportText;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = 0;
+        document.body.appendChild(textarea);
+        textarea.select();
+        try {
+            document.execCommand('copy');
+            alert('Situația a fost copiată în clipboard! (fallback)');
+        } catch (err) {
+            console.error('Fallback: Oops, unable to copy: ', err);
+            alert('Eroare la copierea situației (fallback).');
+        }
+        document.body.removeChild(textarea);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    const copyButton = document.querySelector('.copy-btn[data-target="#situatie-pluton-text"]');
+    if (copyButton) {
+        copyButton.addEventListener('click', function() {
+            copyReportToClipboard('situatie-pluton-text');
+        });
+    }
+});
+</script>
 {% endblock %}

--- a/templates/presence_report.html
+++ b/templates/presence_report.html
@@ -44,7 +44,7 @@
         <div class="card-header bg-primary text-white">
             <div class="d-flex justify-content-between align-items-center">
                 <h4 class="mb-0">{{ report_data.title }}</h4>
-                <button class="btn btn-sm btn-light copy-btn" data-target="#reportTextForCopy" title="Copiază raportul în format text">
+                <button class="btn btn-sm btn-light copy-btn" onclick="copyReportToClipboard('reportTextForCopy')" title="Copiază raportul în format text">
                     <i class="fas fa-copy"></i> Copiază Raport Text
                 </button>
             </div>
@@ -103,29 +103,13 @@
             {% endif %}
             {% endif %}
 
-            {% if report_data.smt_students_details or report_data.smt_count > 0 %} {# Show if there are SMT students or count > 0 #}
             <h5 class="mt-3">
-                <i class="fas fa-user-md text-secondary me-2"></i>SMT (Scutire Medicală Totală)
-                <span class="badge rounded-pill bg-secondary ms-1">{{ report_data.smt_count }}</span>
-            </h5>
-            {% if report_data.smt_students_details %}
-                <ul class="list-group list-group-flush mb-3" style="font-size: 0.9em;">
-                    {% for smt_student in report_data.smt_students_details %}
-                        <li class="list-group-item py-1 ps-2">{{ loop.index }}. {{ smt_student }}</li>
-                    {% endfor %}
-                </ul>
-            {% elif report_data.smt_count == 0 %}
-                <p class="text-muted ms-3"><small>Niciun student SMT.</small></p>
-            {% endif %}
-            {% endif %}
-
-            <h5 class="mt-3">
-                <i class="fas fa-user-times text-danger me-2"></i>Absenți Motivat
+                <i class="fas fa-user-times text-danger me-2"></i>Absenți Motivat (Total)
                 <span class="badge rounded-pill bg-danger ms-1">{{ report_data.efectiv_absent_total }}</span>
             </h5>
-            {% if report_data.absent_students_details %}
+            {% if report_data.all_absent_details %}
                 <ul class="list-group list-group-flush" style="font-size: 0.9em;">
-                    {% for absent_student in report_data.absent_students_details %}
+                    {% for absent_student in report_data.all_absent_details %}
                         <li class="list-group-item py-1 ps-2">{{ loop.index }}. {{ absent_student }}</li>
                     {% endfor %}
                 </ul>
@@ -136,45 +120,11 @@
             {% endif %}
         </div>
         <pre id="reportTextForCopy" class="report-text-block" style="display: none;">
-{{- report_data.title }}
-Data raport: {{ report_data.datetime_checked }}
-
-Efectiv Control (EC): {{ report_data.efectiv_control }}
-Efectiv Prezent (Ep): {{ report_data.efectiv_prezent_total }}
-Efectiv Absent (Ea): {{ report_data.efectiv_absent_total }}
-
-{% if report_data.in_formation_count > 0 -%}
-PREZENȚI ÎN FORMAȚIE ({{ report_data.in_formation_count }}):
-{% for present_student in report_data.in_formation_students_details -%}
-  - {{ present_student }}
-{% endfor %}
-{% endif %}
-
-{% if (report_data.on_duty_students_details | length) > 0 -%}
-LA SERVICII ({{ report_data.on_duty_students_details | length }}):
-{% for duty_student in report_data.on_duty_students_details -%}
-  - {{ duty_student }}
-{% endfor %}
-{% endif %}
-
-{% if report_data.platoon_graded_duty_count > 0 -%}
-GRADAȚI PLUTON (Activitate Specifică) ({{ report_data.platoon_graded_duty_count }}):
-{% for graded_student in report_data.platoon_graded_duty_students_details -%}
-  - {{ graded_student }}
-{% endfor %}
-{% endif %}
-
-{% if report_data.smt_count > 0 -%} {# New SMT section for text report #}
-SMT (Scutire Medicală Totală) ({{ report_data.smt_count }}):
-{% for smt_student in report_data.smt_students_details -%}
-  - {{ smt_student }}
-{% endfor %}
-{% endif %}
-
-{% if report_data.absent_students_details %} {# This list no longer includes SMT #}
-ABSENȚI MOTIVAT ({{ report_data.absent_students_details | length }}): {# Count based on details list length #}
-{% for absent_student in report_data.absent_students_details -%}
-  - {{ absent_student }}
+EC: {{ report_data.efectiv_control }}, EP: {{ report_data.efectiv_prezent_total }}, EA: {{ report_data.efectiv_absent_total }}
+{% if report_data.all_absent_details %}
+Absenti motivat:
+{% for detail in report_data.all_absent_details %}
+- {{ detail }}
 {% endfor %}
 {% endif %}
         </pre>


### PR DESCRIPTION
This commit addresses two main issues:
1.  A bug where students with special roles (e.g., company staff with platoon '0') who were medically exempt were not being displayed in the list of absentees.
2.  A feature request to add a copy-to-clipboard functionality for attendance reports with a specific format.

The `_calculate_presence_data` function in `app.py` has been refactored to consolidate all types of absences (leaves, medical exemptions) into a single list. This ensures that all absent students are correctly accounted for and passed to the templates.

The relevant templates (`company_commander_dashboard.html`, `battalion_commander_dashboard.html`, `presence_report.html`, and `gradat_dashboard.html`) have been updated to use this new consolidated list, fixing the display bug.

Additionally, the copy-to-clipboard functionality has been implemented on all these pages, with the text formatted as "EC: x, EP: x, EA: x" followed by the detailed list of absentees, as requested by the user.