### PR TITLE
fix: Pass current_platoon_situation to gradat_dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -1484,6 +1484,7 @@ def dashboard():
                                weekend_leaves_today_count=weekend_leaves_active_today, # Statistică veche "azi"
                                services_today_count=services_today_count, # Statistică veche "azi"
                                total_volunteer_activities=total_volunteer_activities,
+                               current_platoon_situation=current_platoon_situation,
                                # Date noi pentru "Mini Situație ACUM"
                                sit_total_studenti=current_platoon_situation.get("efectiv_control", 0),
                                sit_prezenti_formatie=current_platoon_situation.get("in_formation_count", 0),


### PR DESCRIPTION
The gradat_dashboard.html template uses the current_platoon_situation variable, but it was not being passed from the dashboard view function in app.py. This caused a jinja2.exceptions.UndefinedError.

This change adds the missing variable to the render_template call to resolve the error.