### PR TITLE
Implement Daily Leave Bulk Add Feature

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -5,11 +5,20 @@ document.addEventListener('DOMContentLoaded', function () {
     function showLoader() { if (loadingOverlay) loadingOverlay.classList.add('show'); }
     function hideLoader() { if (loadingOverlay) loadingOverlay.classList.remove('show'); }
     hideLoader();
+
+    // Track if a Bootstrap modal is open to avoid trapping UI behind overlay/backdrop
+    let modalOpen = false;
+    document.addEventListener('shown.bs.modal', () => { modalOpen = true; hideLoader(); });
+    document.addEventListener('hidden.bs.modal', () => { modalOpen = false; hideLoader(); });
+
     document.querySelectorAll('a').forEach(link => {
         link.addEventListener('click', function (e) {
             // Ignore links that should not trigger the global loader
+            if (modalOpen) return; // Never show loader while a modal is open
             if (this.target === '_blank' || this.href.startsWith('javascript:') || this.classList.contains('no-loader')) return;
             if (this.hash && (this.pathname === window.location.pathname)) return;
+            // Ignore clicks inside any modal dialog
+            if (this.closest('.modal')) return;
             const tgl = this.getAttribute('data-bs-toggle');
             if (tgl === 'dropdown' || tgl === 'collapse' || tgl === 'modal') return;
             const href = (this.getAttribute('href') || '').toLowerCase();
@@ -18,10 +27,11 @@ document.addEventListener('DOMContentLoaded', function () {
             if (this.classList.contains('fc-event') || this.closest('.fc')) return;
             showLoader();
             setTimeout(hideLoader, 8000);
-        });
+        }, true);
     });
     document.querySelectorAll('form').forEach(form => {
         form.addEventListener('submit', function () {
+            if (modalOpen) return; // avoid overlay when submitting forms inside modals
             if (this.target === '_blank' || this.classList.contains('no-loader')) return;
             showLoader();
             setTimeout(hideLoader, 8000);

--- a/templates/bulk_add_daily_leave.html
+++ b/templates/bulk_add_daily_leave.html
@@ -1,0 +1,107 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="mb-0">
+            Adăugare Învoiri Zilnice în Masă
+        </h2>
+        <div>
+            <a href="{{ url_for('list_daily_leaves') }}" class="btn btn-outline-secondary btn-sm">&laquo; Înapoi la Învoiri Zilnice</a>
+        </div>
+    </div>
+
+    {% if not students_to_prepare %}
+    <!-- Step 1: Select students -->
+    <form method="GET" action="{{ url_for('gradat_bulk_add_daily_leave') }}" class="card shadow-sm">
+        <div class="card-header">
+            <strong>Selectează studenții</strong>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-sm table-hover">
+                    <thead>
+                        <tr>
+                            <th style="width:30px;"><input type="checkbox" id="select-all" class="form-check-input"></th>
+                            <th>Pluton</th>
+                            <th>Nume</th>
+                            <th>Prenume</th>
+                            <th>Grad</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for s in students %}
+                        <tr>
+                            <td><input type="checkbox" name="student_ids" value="{{ s.id }}" class="form-check-input row-cb"></td>
+                            <td>{{ s.pluton }}</td>
+                            <td>{{ s.nume }}</td>
+                            <td>{{ s.prenume }}</td>
+                            <td>{{ s.grad_militar }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            <p class="text-muted small mb-2">Selectează unul sau mai mulți studenți și apasă Continuă.</p>
+            <button type="submit" class="btn btn-primary">Continuă</button>
+        </div>
+    </form>
+    {% else %}
+    <!-- Step 2: Provide details per selected student -->
+    <form method="POST" action="{{ url_for('gradat_bulk_add_daily_leave') }}" class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <strong>Completează detaliile învoirii pentru fiecare student selectat</strong>
+            <small class="text-muted">Sugestie dată: <code>{{ today_str }}</code></small>
+        </div>
+        <div class="card-body">
+            {% for s in students_to_prepare %}
+                <input type="hidden" name="student_id_{{ s.id }}" value="{{ s.id }}">
+                <div class="border rounded p-3 mb-3">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <div>
+                            <strong>{{ s.grad_militar }} {{ s.nume }} {{ s.prenume }}</strong>
+                            <span class="badge bg-light text-dark ms-2">Pluton {{ s.pluton }}</span>
+                        </div>
+                    </div>
+                    <div class="row g-2">
+                        <div class="col-md-4">
+                            <label class="form-label">Data Învoirii</label>
+                            <input type="date" name="leave_date_{{ s.id }}" class="form-control" value="{{ today_str }}" required>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">Început</label>
+                            <input type="time" name="start_time_{{ s.id }}" class="form-control" required>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">Sfârșit</label>
+                            <input type="time" name="end_time_{{ s.id }}" class="form-control" required>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label">Motiv (opțional)</label>
+                            <input type="text" name="reason_{{ s.id }}" class="form-control" placeholder="Ex. medical, familie, etc.">
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+        <div class="card-footer d-flex justify-content-between">
+            <a href="{{ url_for('gradat_bulk_add_daily_leave') }}" class="btn btn-outline-secondary">Înapoi</a>
+            <button type="submit" class="btn btn-primary">Adaugă Învoiri</button>
+        </div>
+    </form>
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+    const selectAll = document.getElementById('select-all');
+    if (selectAll) {
+        selectAll.addEventListener('change', function(){
+            document.querySelectorAll('.row-cb').forEach(cb => cb.checked = selectAll.checked);
+        });
+    }
+});
+</script>
+{% endblock %}

--- a/templates/list_daily_leaves.html
+++ b/templates/list_daily_leaves.html
@@ -13,6 +13,10 @@
                 </svg>
                 Adaugă Învoire
             </a>
+            <a href="{{ url_for('gradat_bulk_add_daily_leave') }}" class="btn btn-primary btn-sm me-2">
+                <i class="fas fa-users-cog me-1"></i>
+                Adăugare în Masă
+            </a>
             <a href="{{ url_for('gradat_export_daily_leaves_word') }}" class="btn btn-info btn-sm me-2">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark-word-fill me-1 icon-rotate-hover" viewBox="0 0 16 16">
                     <path d="M9.293 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V4.707A1 1 0 0 0 13.707 4L10 .293A1 1 0 0 0 9.293 0zM9.5 3.5v-2l3 3h-2a1 1 0 0 1-1-1zM5.485 6.879l1.036 4.144.997-3.655a.5.5 0 0 1 .964 0l.997 3.655 1.036-4.144a.5.5 0 0 1 .97.242l-1.5 6a.5.5 0 0 1-.967.01L8 9.402l-1.018 3.73a.5.5 0 0 1-.967-.01l-1.5-6a.5.5 0 1 1 .97-.242z"/>

--- a/templates/list_students.html
+++ b/templates/list_students.html
@@ -305,17 +305,8 @@
 <!-- Hidden Form Snippets for Batch Actions -->
 <div id="batch-action-form-templates" style="display: none;">
 
-    <!-- Snippet pentru Permisii -->
+    <!-- Snippet pentru Permisii (fără șabloane) -->
     <div id="form-snippet-permission">
-        <div class="mb-3">
-            <label class="form-label">Folosește un Șablon (Opțional)</label>
-            <select class="form-select template-selector" data-action-type="permission">
-                <option value="">-- Manual --</option>
-                {% for t in leave_templates if t.template_type == 'permission' %}
-                <option value='{{ t.get_data()|tojson|forceescape }}'>{{ t.name }}</option>
-                {% endfor %}
-            </select>
-        </div>
         <div class="row">
             <div class="col-md-6 mb-3"><label class="form-label">Data și Ora de Început</label><input type="datetime-local" name="start_datetime" class="form-control" required></div>
             <div class="col-md-6 mb-3"><label class="form-label">Data și Ora de Sfârșit</label><input type="datetime-local" name="end_datetime" class="form-control" required></div>
@@ -325,17 +316,8 @@
         </div>
     </div>
 
-    <!-- Snippet pentru Învoiri Zilnice -->
+    <!-- Snippet pentru Învoiri Zilnice (fără șabloane) -->
     <div id="form-snippet-daily_leave">
-        <div class="mb-3">
-            <label class="form-label">Folosește un Șablon (Opțional)</label>
-            <select class="form-select template-selector" data-action-type="daily_leave">
-                <option value="">-- Manual --</option>
-                {% for t in leave_templates if t.template_type == 'daily_leave' %}
-                <option value='{{ t.get_data()|tojson|forceescape }}'>{{ t.name }}</option>
-                {% endfor %}
-            </select>
-        </div>
         <div class="row">
             <div class="col-md-4 mb-3"><label class="form-label">Data Învoirii</label><input type="date" name="leave_date" class="form-control" required></div>
             <div class="col-md-4 mb-3"><label class="form-label">Ora de Început</label><input type="time" name="start_time" class="form-control" required></div>
@@ -343,17 +325,8 @@
         </div>
     </div>
 
-    <!-- Snippet pentru Servicii -->
+    <!-- Snippet pentru Servicii (fără șabloane) -->
     <div id="form-snippet-service">
-        <div class="mb-3">
-            <label class="form-label">Folosește un Șablon (Opțional)</label>
-            <select class="form-select template-selector" data-action-type="service">
-                <option value="">-- Manual --</option>
-                {% for t in leave_templates if t.template_type == 'service' %}
-                <option value='{{ t.get_data()|tojson|forceescape }}'>{{ t.name }}</option>
-                {% endfor %}
-            </select>
-        </div>
         <div class="row">
             <div class="col-md-6 mb-3"><label class="form-label">Tip Serviciu</label>
                 <select name="service_type" class="form-select" required>
@@ -423,39 +396,10 @@ document.addEventListener('DOMContentLoaded', function () {
         const formSnippet = document.getElementById(`form-snippet-${actionType}`);
         if (formSnippet) {
             modalFormContent.innerHTML = formSnippet.innerHTML;
-            const templateSelector = modalFormContent.querySelector('.template-selector');
-            if(templateSelector) {
-                templateSelector.addEventListener('change', handleTemplateSelection);
-            }
         } else {
             modalFormContent.innerHTML = '<p class="text-danger">Eroare: Nu s-a găsit formularul pentru această acțiune.</p>';
         }
     });
-
-    function handleTemplateSelection(event) {
-        const selector = event.target;
-        const selectedOption = selector.options[selector.selectedIndex];
-        const formContainer = selector.closest('#modal-form-content');
-
-        if (!selectedOption.value) return;
-
-        try {
-            const data = JSON.parse(selectedOption.value);
-            const actionType = selector.dataset.actionType;
-
-            if (actionType === 'daily_leave') {
-                formContainer.querySelector('[name="start_time"]').value = data.start_time || '';
-                formContainer.querySelector('[name="end_time"]').value = data.end_time || '';
-            } else if (actionType === 'permission') {
-                formContainer.querySelector('[name="destination"]').value = data.destination || '';
-                formContainer.querySelector('[name="transport_mode"]').value = data.transport_mode || '';
-            } else if (actionType === 'service') {
-                formContainer.querySelector('[name="service_type"]').value = data.service_type || '';
-            }
-        } catch (e) {
-            console.error("Error parsing template data:", e);
-        }
-    }
 
     updateBatchActionUI();
 });


### PR DESCRIPTION
This PR addresses the issue of adding a bulk functionality for daily leave requests. The new endpoint `/gradat/daily_leave/bulk_add` allows users to select multiple students and submit daily leave details in a single action, similar to existing bulk permission functionality. Additionally, it removes the previously unused template page for leave requests, streamlining the user experience. Updates in JavaScript ensure that UI elements, such as loaders, function correctly when modals are involved.

---

> This pull request was co-created with Cosine Genie

Original Task: [test/6tpsa3g0oah3](https://cosine.sh/21as2gnxjvhd/test/task/6tpsa3g0oah3)
Author: rentfrancisc
