### PR TITLE
Fix AttributeError for Flask before_first_request

### DIFF
--- a/app.py
+++ b/app.py
@@ -200,9 +200,14 @@ def _auto_apply_migrations_and_seed():
         db.session.rollback()
 
 
-@app.before_first_request
-def _bootstrap_db_on_first_request():
-    _auto_apply_migrations_and_seed()
+_db_bootstrapped_once = False
+
+@app.before_request
+def _bootstrap_db_once():
+    global _db_bootstrapped_once
+    if not _db_bootstrapped_once:
+        _auto_apply_migrations_and_seed()
+        _db_bootstrapped_once = True
 
 login_manager = LoginManager(app)
 login_manager.login_view = "user_login"


### PR DESCRIPTION
This PR resolves the AttributeError encountered due to the incorrect usage of `before_first_request` in the Flask application. The `_bootstrap_db_on_first_request` function was modified to instead use `before_request`. Now, the database bootstrap will occur on the first request instead of on the first request event, ensuring that migrations and seeding are properly applied. This change prevents the application from raising errors related to the non-existent attribute.

---

> This pull request was co-created with Cosine Genie

Original Task: [test/2sab0mv9w1wb](https://cosine.sh/21as2gnxjvhd/test/task/2sab0mv9w1wb)
Author: rentfrancisc
