### PR TITLE
feat: Implement situation snapshots and improve exports

### DIFF
--- a/templates/gradat_dashboard.html
+++ b/templates/gradat_dashboard.html
@@ -5,9 +5,16 @@
 <div class="container mt-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2 class="mb-0">Panou de Control Gradat: {{ current_user.username }}</h2>
-        <a href="{{ url_for('presence_report') }}" class="btn btn-info">
-            <i class="fas fa-file-alt me-1"></i> Generează Raport Prezență
-        </a>
+        <div class="btn-group">
+            {% if not current_user.parent_user_id %}
+            <a href="{{ url_for('gradat_manage_subusers') }}" class="btn btn-secondary">
+                <i class="fas fa-users-cog me-1"></i> Gestionează Subutilizatori
+            </a>
+            {% endif %}
+            <a href="{{ url_for('presence_report') }}" class="btn btn-info">
+                <i class="fas fa-file-alt me-1"></i> Generează Raport Prezență
+            </a>
+        </div>
     </div>
     <!-- Mini Situație Pluton (ACUM) -->
     <div class="mt-2 p-3 border rounded bg-light shadow-sm">

--- a/templates/list_situations.html
+++ b/templates/list_situations.html
@@ -10,8 +10,44 @@
   </a>
 </div>
 
-<p class="text-muted">Creează și distribuie formulare personalizate (situații/tabele) pentru a colecta informații direct de la studenți. Poți genera link public temporar pentru completare.</p>
+<p class="text-muted">Aici poți defini formulare personalizate (situații/tabele) pentru a colecta informații. Mai jos poți salva o copie a stării curente a datelor (învoiri, permisii, etc.) sau poți vizualiza/restaura situațiile salvate anterior.</p>
 
+<div class="row">
+    <div class="col-md-6 mb-4">
+        <div class="card shadow-sm h-100">
+            <div class="card-header">
+                <h5 class="mb-0"><i class="fas fa-save me-2"></i> Salvează Situația Curentă (Snapshot)</h5>
+            </div>
+            <div class="card-body">
+                <p class="text-muted small">Salvează starea curentă a tuturor permisiilor și învoirilor pentru studenții tăi. Vei putea vizualiza această stare mai târziu sau chiar reseta datele la această versiune.</p>
+                <form action="{{ url_for('create_situation_snapshot') }}" method="POST">
+                    <div class="input-group">
+                        <input type="text" class="form-control" name="snapshot_name" placeholder="Nume (ex: 'Situație Săpt. 10')" required>
+                        <button class="btn btn-success" type="submit">
+                            <i class="fas fa-save me-1"></i> Salvează Acum
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6 mb-4">
+        <div class="card shadow-sm h-100">
+            <div class="card-header">
+                <h5 class="mb-0"><i class="fas fa-history me-2"></i> Gestionează Situațiile Salvate</h5>
+            </div>
+            <div class="card-body">
+                <p class="text-muted small">Vezi toate situațiile pe care le-ai salvat. Poți vizualiza, șterge sau restaura o situație, suprascriind datele curente cu cele din copia salvată.</p>
+                <a href="{{ url_for('list_situation_snapshots') }}" class="btn btn-info w-100">
+                    <i class="fas fa-cogs me-1"></i> Mergi la Management
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+<h3 class="mt-4 mb-3">Formulare Personalizate</h3>
 <div class="card shadow-sm">
   <div class="list-group list-group-flush">
     {% if situations %}

--- a/templates/list_snapshots.html
+++ b/templates/list_snapshots.html
@@ -1,0 +1,81 @@
+{% extends "base.html" %}
+
+{% block title %}Gestionează Situațiile Salvate{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h2 class="mb-0"><i class="fas fa-history me-2"></i> Gestionează Situațiile Salvate (Snapshots)</h2>
+  <a href="{{ url_for('list_situations') }}" class="btn btn-outline-secondary">
+    <i class="fas fa-arrow-left me-2"></i> Înapoi la Formulare
+  </a>
+</div>
+
+<p class="text-muted">Aici poți vizualiza, șterge sau restaura o situație salvată. Restaurarea unei situații va suprascrie toate datele curente (permisii, învoiri, servicii) pentru studenții tăi cu cele din copia salvată. Această acțiune nu poate fi anulată.</p>
+
+<div class="card shadow-sm">
+  <div class="list-group list-group-flush">
+    {% if snapshots %}
+      {% for s in snapshots %}
+      <div class="list-group-item">
+        <div class="d-flex w-100 justify-content-between">
+          <h5 class="mb-1">{{ s.name }}</h5>
+          <small class="text-muted">Salvat la: {{ s.created_at | localdatetime }}</small>
+        </div>
+        <p class="mb-1">
+            <span class="badge bg-primary">Permisii: {{ s.data_summary.permissions }}</span>
+            <span class="badge bg-success">Învoiri Zilnice: {{ s.data_summary.daily_leaves }}</span>
+            <span class="badge bg-info">Învoiri Weekend: {{ s.data_summary.weekend_leaves }}</span>
+            <span class="badge bg-warning text-dark">Servicii: {{ s.data_summary.service_assignments }}</span>
+        </p>
+        <div class="mt-2">
+            <a href="{{ url_for('view_situation_snapshot', snapshot_id=s.id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-eye me-1"></i> Vizualizează</a>
+
+            <button class="btn btn-sm btn-outline-info copy-link-btn" data-link="{{ url_for('public_snapshot_view', snapshot_id=s.id, _external=True) }}">
+                <i class="fas fa-link me-1"></i> Copiază Link Public
+            </button>
+
+            <form action="{{ url_for('reset_situation_snapshot', snapshot_id=s.id) }}" method="POST" onsubmit="return confirm('ATENȚIE! Ești sigur că vrei să restaurezi această situație? Toate învoirile și permisiile curente vor fi ȘTERSE și înlocuite cu cele din această copie. Acțiunea este ireversibilă.');" style="display:inline;">
+                <button type="submit" class="btn btn-sm btn-danger"><i class="fas fa-undo me-1"></i> Restaurează</button>
+            </form>
+
+            <form action="{{ url_for('delete_situation_snapshot', snapshot_id=s.id) }}" method="POST" onsubmit="return confirm('Ești sigur că vrei să ștergi această situație salvată? Acțiunea este ireversibilă.');" style="display:inline;">
+                <button type="submit" class="btn btn-sm btn-outline-danger"><i class="fas fa-trash me-1"></i> Șterge</button>
+            </form>
+        </div>
+      </div>
+      {% endfor %}
+    {% else %}
+      <div class="list-group-item">
+        <div class="alert alert-info mb-0">Nu ai nicio situație salvată.</div>
+      </div>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('.copy-link-btn').forEach(button => {
+        button.addEventListener('click', function() {
+            const link = this.dataset.link;
+            navigator.clipboard.writeText(link).then(() => {
+                const originalText = this.innerHTML;
+                this.innerHTML = '<i class="fas fa-check me-1"></i> Copiat!';
+                this.classList.remove('btn-outline-info');
+                this.classList.add('btn-success');
+                setTimeout(() => {
+                    this.innerHTML = originalText;
+                    this.classList.remove('btn-success');
+                    this.classList.add('btn-outline-info');
+                }, 2000);
+            }).catch(err => {
+                console.error('Failed to copy: ', err);
+                alert('Nu s-a putut copia link-ul.');
+            });
+        });
+    });
+});
+</script>
+{% endblock %}

--- a/templates/view_snapshot.html
+++ b/templates/view_snapshot.html
@@ -1,0 +1,194 @@
+{% extends "base.html" %}
+
+{% block title %}Vizualizare Situație Salvată{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    {% if is_public %}
+    <div class="alert alert-info"><i class="fas fa-eye me-2"></i>Aceasta este o vizualizare publică, doar pentru citire.</div>
+    {% endif %}
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div>
+            <h2 class="mb-0"><i class="fas fa-file-invoice me-2"></i> Vizualizare: {{ snapshot.name }}</h2>
+            <p class="text-muted mb-0">Salvat la: {{ snapshot.created_at | localdatetime }}</p>
+        </div>
+        {% if not is_public %}
+        <a href="{{ url_for('list_situation_snapshots') }}" class="btn btn-outline-secondary">
+            <i class="fas fa-arrow-left me-2"></i> Înapoi la Listă
+        </a>
+        {% endif %}
+    </div>
+
+    {% set student_map = {} %}
+    {% for s in snapshot.data.students %}
+        {% set _ = student_map.update({s.id_unic_student: s}) %}
+    {% endfor %}
+
+    <!-- Permissions -->
+    <div class="card shadow-sm mb-4">
+        <div class="card-header">
+            <h5 class="mb-0">Permisii ({{ snapshot.data.permissions|length }})</h5>
+        </div>
+        <div class="card-body">
+            {% if snapshot.data.permissions %}
+            <div class="table-responsive">
+                <table class="table table-striped table-sm">
+                    <thead>
+                        <tr>
+                            <th>Student</th>
+                            <th>Start</th>
+                            <th>Sfârșit</th>
+                            <th>Destinație</th>
+                            <th>Transport</th>
+                            <th>Motiv</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for p in snapshot.data.permissions %}
+                        <tr>
+                            <td>
+                                {% set student_info = student_map.get(p.student_unique_id) %}
+                                {{ student_info.grad_militar if student_info else '' }} {{ student_info.nume if student_info else 'N/A' }} {{ student_info.prenume if student_info else '' }}
+                            </td>
+                            <td>{{ p.start_datetime | localdatetime }}</td>
+                            <td>{{ p.end_datetime | localdatetime }}</td>
+                            <td>{{ p.destination }}</td>
+                            <td>{{ p.transport_mode }}</td>
+                            <td>{{ p.reason }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+            <p class="text-muted">Nicio permisie în această situație.</p>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- Daily Leaves -->
+    <div class="card shadow-sm mb-4">
+        <div class="card-header">
+            <h5 class="mb-0">Învoiri Zilnice ({{ snapshot.data.daily_leaves|length }})</h5>
+        </div>
+        <div class="card-body">
+            {% if snapshot.data.daily_leaves %}
+            <div class="table-responsive">
+                <table class="table table-striped table-sm">
+                    <thead>
+                        <tr>
+                            <th>Student</th>
+                            <th>Data</th>
+                            <th>Start</th>
+                            <th>Sfârșit</th>
+                            <th>Motiv</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for dl in snapshot.data.daily_leaves %}
+                        <tr>
+                            <td>
+                                {% set student_info = student_map.get(dl.student_unique_id) %}
+                                {{ student_info.grad_militar if student_info else '' }} {{ student_info.nume if student_info else 'N/A' }} {{ student_info.prenume if student_info else '' }}
+                            </td>
+                            <td>{{ dl.leave_date | localdate }}</td>
+                            <td>{{ dl.start_time | localtime }}</td>
+                            <td>{{ dl.end_time | localtime }}</td>
+                            <td>{{ dl.reason }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+            <p class="text-muted">Nicio învoire zilnică în această situație.</p>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- Weekend Leaves -->
+    <div class="card shadow-sm mb-4">
+        <div class="card-header">
+            <h5 class="mb-0">Învoiri Weekend ({{ snapshot.data.weekend_leaves|length }})</h5>
+        </div>
+        <div class="card-body">
+            {% if snapshot.data.weekend_leaves %}
+            <div class="table-responsive">
+                <table class="table table-striped table-sm">
+                    <thead>
+                        <tr>
+                            <th>Student</th>
+                            <th>Data Weekend (Vineri)</th>
+                            <th>Detalii Zile</th>
+                            <th>Biserică</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for wl in snapshot.data.weekend_leaves %}
+                        <tr>
+                            <td>
+                                {% set student_info = student_map.get(wl.student_unique_id) %}
+                                {{ student_info.grad_militar if student_info else '' }} {{ student_info.nume if student_info else 'N/A' }} {{ student_info.prenume if student_info else '' }}
+                            </td>
+                            <td>{{ wl.weekend_start_date | localdate }}</td>
+                            <td>
+                                {% set days = [] %}
+                                {% if wl.day1_selected %}{% set _ = days.append(wl.day1_selected + ' (' + (wl.day1_start_time | localtime) + '-' + (wl.day1_end_time | localtime) + ')') %}{% endif %}
+                                {% if wl.day2_selected %}{% set _ = days.append(wl.day2_selected + ' (' + (wl.day2_start_time | localtime) + '-' + (wl.day2_end_time | localtime) + ')') %}{% endif %}
+                                {% if wl.day3_selected %}{% set _ = days.append(wl.day3_selected + ' (' + (wl.day3_start_time | localtime) + '-' + (wl.day3_end_time | localtime) + ')') %}{% endif %}
+                                {{ days | join('; ') }}
+                            </td>
+                            <td>{{ 'Da' if wl.duminica_biserica else 'Nu' }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+            <p class="text-muted">Nicio învoire de weekend în această situație.</p>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- Service Assignments -->
+    <div class="card shadow-sm mb-4">
+        <div class="card-header">
+            <h5 class="mb-0">Servicii ({{ snapshot.data.service_assignments|length }})</h5>
+        </div>
+        <div class="card-body">
+            {% if snapshot.data.service_assignments %}
+            <div class="table-responsive">
+                <table class="table table-striped table-sm">
+                    <thead>
+                        <tr>
+                            <th>Student</th>
+                            <th>Tip Serviciu</th>
+                            <th>Start</th>
+                            <th>Sfârșit</th>
+                            <th>Note</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for srv in snapshot.data.service_assignments %}
+                        <tr>
+                            <td>
+                                {% set student_info = student_map.get(srv.student_unique_id) %}
+                                {{ student_info.grad_militar if student_info else '' }} {{ student_info.nume if student_info else 'N/A' }} {{ student_info.prenume if student_info else '' }}
+                            </td>
+                            <td>{{ srv.service_type }}</td>
+                            <td>{{ srv.start_datetime | localdatetime }}</td>
+                            <td>{{ srv.end_datetime | localdatetime }}</td>
+                            <td>{{ srv.notes }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+            <p class="text-muted">Niciun serviciu în această situație.</p>
+            {% endif %}
+        </div>
+    </div>
+
+</div>
+{% endblock %}


### PR DESCRIPTION
This commit introduces several new features and improvements:

1.  **Situation Snapshots:**
    - A new system allows `gradat` users to save a complete snapshot of their students' current permissions, leaves, and service assignments.
    - Snapshots are stored as JSON files in the `instance/snapshots/` directory, avoiding any database schema changes.
    - Users can view, delete, and restore the application state from a saved snapshot. A restore operation is performed within a database transaction for safety.
    - Public, shareable links can be generated for each snapshot, allowing read-only viewing without authentication.

2.  **Improved Word Exports:**
    - The Word document export for "permisii" (permissions) has been reformatted to match user specifications, now including columns for "Grupa", "Localitatea", and "Transport".
    - The Word document export for "învoiri" (daily leaves) has been completely redesigned. It now groups students by platoon and date, merging the corresponding cells for a cleaner, more organized report as specified.

3.  **UI and Bug Fixes:**
    - The "Gestionează Subutilizatori" (Manage Sub-users) button is now visible again on the `gradat` dashboard.
    - Fixed a `TypeError` that occurred when comparing timezone-aware and timezone-naive datetimes in the permissions list by using the model's timezone-aware properties.