### PR TITLE
Exclude Gradați from Volunteer Calculations and Improve Dark Mode Visibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -6640,6 +6640,7 @@ def _generate_eligible_volunteers(
 ):
     """
     Helper function to generate a list of eligible students for volunteering.
+    Note: Excludes 'gradați' (leaders) from volunteer generation.
     """
     students_query = Student.query.filter_by(created_by_user_id=gradat_id)
 
@@ -6651,6 +6652,14 @@ def _generate_eligible_volunteers(
     students_query = students_query.filter(
         or_(Student.exemption_details == None, Student.exemption_details == "")
     )
+
+    # Exclude platoon/company/battalion graded duty (gradați)
+    students_query = students_query.filter(Student.is_platoon_graded_duty == False)
+    students_query = students_query.filter(
+        or_(Student.assigned_graded_platoon == None, Student.assigned_graded_platoon == "")
+    )
+    # Exclude personnel marked as company/battalion staff by convention (pluton == '0')
+    students_query = students_query.filter(Student.pluton != "0")
 
     # Exclude students already provided in the exclusion list (e.g., from a session)
     if exclude_student_ids:

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -237,6 +237,28 @@ html { scroll-behavior: smooth; }
 [data-theme="dark"] .list-group-item-success { background-color: rgba(40, 167, 69, 0.15); }
 [data-theme="dark"] .list-group-item-warning { background-color: rgba(255, 193, 7, 0.15); }
 [data-theme="dark"] .list-group-item-danger { background-color: rgba(220, 53, 69, 0.15); }
+
+/* Highlight volunteer lists/cards more visibly in dark mode */
+[data-theme="dark"] .card .list-group-item .fw-bold {
+    color: #8ab4ff !important; /* brighter title for activity (link or span) */
+}
+[data-theme="dark"] .card .list-group-item .badge.bg-light.text-dark {
+    background-color: #3a3a3a !important;
+    color: #eaeaea !important;
+    border: 1px solid var(--border-color);
+}
+[data-theme="dark"] .card .list-group-item {
+    box-shadow: inset 0 0 0 1px rgba(255,255,255,0.02);
+}
+[data-theme="dark"] .card .list-group-item:hover {
+    background-color: var(--bg-surface-hover);
+}
+
+/* Make ranking badges pop in dark mode */
+[data-theme="dark"] .badge.fs-6.bg-danger { filter: brightness(1.1) saturate(1.1); }
+[data-theme="dark"] .badge.fs-6.bg-warning.text-dark { filter: brightness(1.0) saturate(1.1); }
+[data-theme="dark"] .badge.fs-6.bg-info.text-dark { filter: brightness(1.1) saturate(1.1); }
+[data-theme="dark"] .badge.fs-6.bg-success { filter: brightness(1.05) saturate(1.1); }
 /* === END CONSOLIDATED DARK MODE TABLE/LIST STYLING === */
 
 /* General Modal Styling (ensure visibility) */

--- a/templates/volunteer_home.html
+++ b/templates/volunteer_home.html
@@ -91,7 +91,7 @@
                                 <small class="text-muted">{{ activity.activity_date|localdate('%d %B %Y') }} - {{ activity.description if activity.description else 'Fără descriere' }}</small><br>
                                 <span class="badge bg-light text-dark">Participanți: {{ activity.participants.count() }}</span>
                             </div>
-                            <div>
+                            <div class="d-flex align-items-center">
                                 <a href="{{ url_for('volunteer_activity_details', activity_id=activity.id) }}" class="btn btn-sm btn-outline-primary me-2" title="Detalii și Management Participanți">
                                     <i class="fas fa-users"></i> Detalii
                                 </a>


### PR DESCRIPTION
This PR implements two significant changes: First, it updates the volunteer selection logic to exclude 'gradați' (leaders) from being considered for volunteering opportunities, ensuring that only eligible students participate. The logic has been adjusted to filter out students assigned to graded duties. 

Second, it enhances the visibility of volunteer lists in dark mode by modifying the CSS styles. Important elements like titles and badges associated with volunteer cards have been altered to ensure better contrast and readability, thus improving the user experience in dark mode.

---

> This pull request was co-created with Cosine Genie

Original Task: [test/5p248g5qjnby](https://cosine.sh/21as2gnxjvhd/test/task/5p248g5qjnby)
Author: rentfrancisc
