### PR TITLE
Enhance Volunteer Activity Management with Time Slots and Filtering

### DIFF
--- a/migrations/versions/1a2b3c4d5e67_add_time_fields_to_volunteer_activity.py
+++ b/migrations/versions/1a2b3c4d5e67_add_time_fields_to_volunteer_activity.py
@@ -1,0 +1,27 @@
+"""add time fields to volunteer_activity
+
+Revision ID: 1a2b3c4d5e67
+Revises: 9a1c2d3e4f56
+Create Date: 2025-09-16 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1a2b3c4d5e67'
+down_revision = '9a1c2d3e4f56'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('volunteer_activity') as batch_op:
+        batch_op.add_column(sa.Column('start_time', sa.Time(), nullable=True))
+        batch_op.add_column(sa.Column('end_time', sa.Time(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('volunteer_activity') as batch_op:
+        batch_op.drop_column('end_time')
+        batch_op.drop_column('start_time')

--- a/templates/volunteer_activity_create.html
+++ b/templates/volunteer_activity_create.html
@@ -24,6 +24,21 @@
                             <label for="activity_date" class="form-label">Data Activității <span class="text-danger">*</span></label>
                             <input type="date" class="form-control" id="activity_date" name="activity_date" value="{{ today_str }}" required>
                         </div>
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="start_time" class="form-label">Ora început (opțional)</label>
+                                <input type="time" class="form-control" id="start_time" name="start_time" placeholder="HH:MM">
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label for="end_time" class="form-label">Ora sfârșit (opțional)</label>
+                                <input type="time" class="form-control" id="end_time" name="end_time" placeholder="HH:MM">
+                            </div>
+                        </div>
+                        <div class="alert alert-light border">
+                            <small>
+                                Dacă setezi intervalul orar, voluntarii vor apărea ca "Voluntariat" la prezență doar în acel interval, nu toată ziua.
+                            </small>
+                        </div>
                         <div class="d-grid gap-2 d-md-flex justify-content-md-end">
                             <a href="{{ url_for('volunteer_home') }}" class="btn btn-secondary me-md-2">
                                 <i class="fas fa-times me-1"></i> Anulează


### PR DESCRIPTION
This pull request introduces functionality to manage volunteer activities with specific start and end times, ensuring volunteers are marked as absent only during their scheduled activity times. Key changes include:

1. **New Time Fields**: Added `start_time` and `end_time` fields to the `VolunteerActivity` model, allowing activities to specify when they start and end.
2. **Presence Calculation**: Updated the presence calculation logic to only consider volunteers as absent during the configured time window of their activities.
3. **UI Updates**: Adjusted the activity creation form to allow setting optional start and end times.
4. **Grading Exclusion**: Excluded grades and staff from both public and private volunteer rankings as per requirements.

These changes address the need for more accurate volunteer attendance tracking and ensure a straightforward user experience when creating volunteer activities.

---

> This pull request was co-created with Cosine Genie

Original Task: [test/bolg163oceey](https://cosine.sh/21as2gnxjvhd/test/task/bolg163oceey)
Author: rentfrancisc
