### PR TITLE
Add Public Permissions Ranking Feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -7271,6 +7271,233 @@ def public_volunteer_view_slug(slug):
     return redirect(url_for('public_volunteer_view_code', code=sac.code))
 
 
+# === Public Permissions Ranking (similar to Volunteer public ranking) ===
+
+@app.route("/permissions/links", methods=["GET"], endpoint="permissions_links_manage")
+@login_required
+def permissions_links_manage():
+    if current_user.role != "gradat" or getattr(current_user, "parent_user_id", None):
+        flash("Acces neautorizat.", "danger")
+        return redirect(url_for("dashboard"))
+    return render_template("permissions_links.html")
+
+
+@app.route("/permissions/api/generate_link", methods=["POST"], endpoint="permissions_generate_public_link")
+@login_required
+def permissions_generate_public_link():
+    if current_user.role != "gradat" or getattr(current_user, "parent_user_id", None):
+        return jsonify({"error": "Acces neautorizat."}), 403
+
+    payload = request.get_json(silent=True) or {}
+    permanent = bool(payload.get("permanent", False))
+    regenerate = bool(payload.get("regenerate", False))
+    days = 365 * 100 if permanent else int(payload.get("days", 90))
+    days = max(1, min(days, 365 * 100))
+    expires_at = datetime.now(timezone.utc) + timedelta(days=days)
+
+    # Revoke existing permission-ranking public links if regenerate is requested
+    permissions_list = ["/public/permissions/", "/public/p/"]
+    if regenerate:
+        try:
+            existing_codes = ScopedAccessCode.query.filter_by(
+                created_by_user_id=current_user.id, is_active=True
+            ).all()
+            for c in existing_codes:
+                try:
+                    perms = c.get_permissions_list()
+                except Exception:
+                    perms = []
+                if any(p in perms for p in permissions_list) and c.expires_at > datetime.now(timezone.utc):
+                    c.is_active = False
+            db.session.flush()
+        except Exception as e:
+            db.session.rollback()
+            return jsonify({"error": f"Eroare la revocarea codurilor vechi: {e}"}), 500
+
+    new_code = ScopedAccessCode(
+        code=_generate_unique_scoped_code_str(16),
+        description="Clasament Permisii Public",
+        permissions=json.dumps(permissions_list, ensure_ascii=False),
+        expires_at=expires_at,
+        created_by_user_id=current_user.id,
+        is_active=True,
+    )
+    db.session.add(new_code)
+    try:
+        db.session.commit()
+        return jsonify({
+            "code": new_code.code,
+            "public_url": url_for("public_permissions_view_code", code=new_code.code, _external=True),
+            "expires_at": new_code.expires_at.isoformat(),
+            "never_expires": permanent,
+        }), 200
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({"error": f"Eroare la generarea codului: {e}"}), 500
+
+
+@app.route("/permissions/api/list_links", methods=["GET"], endpoint="permissions_list_public_links")
+@login_required
+def permissions_list_public_links():
+    if current_user.role != "gradat" or getattr(current_user, "parent_user_id", None):
+        return jsonify({"error": "Acces neautorizat."}), 403
+
+    now = datetime.now(timezone.utc)
+    codes = ScopedAccessCode.query.filter_by(
+        created_by_user_id=current_user.id, is_active=True
+    ).filter(ScopedAccessCode.expires_at > now).all()
+
+    results = []
+    for c in codes:
+        try:
+            perms = c.get_permissions_list()
+        except Exception:
+            perms = []
+        if any(p in perms for p in ["/public/permissions/", "/public/p/"]):
+            never_expires = (c.expires_at - now) > timedelta(days=365 * 20)
+            results.append({
+                "code": c.code,
+                "expires_at": c.expires_at.isoformat(),
+                "public_url": url_for("public_permissions_view_code", code=c.code, _external=True),
+                "never_expires": never_expires,
+            })
+    results.sort(key=lambda x: x["expires_at"], reverse=True)
+    return jsonify({"codes": results})
+
+
+@app.route("/permissions/api/revoke_link", methods=["POST"], endpoint="permissions_revoke_public_link")
+@login_required
+def permissions_revoke_public_link():
+    if current_user.role != "gradat" or getattr(current_user, "parent_user_id", None):
+        return jsonify({"error": "Acces neautorizat."}), 403
+
+    payload = request.get_json(silent=True) or {}
+    code = (payload.get("code") or "").strip()
+    if not code:
+        return jsonify({"error": "Cod lipsă."}), 400
+
+    sac = ScopedAccessCode.query.filter_by(code=code, created_by_user_id=current_user.id).first()
+    if not sac:
+        return jsonify({"error": "Cod invalid."}), 404
+
+    sac.is_active = False
+    try:
+        db.session.commit()
+        return jsonify({"ok": True})
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({"error": f"Eroare la revocare: {e}"}), 500
+
+
+@app.route("/permissions/api/set_slug", methods=["POST"], endpoint="permissions_set_public_slug")
+@login_required
+def permissions_set_public_slug():
+    if current_user.role != "gradat" or getattr(current_user, "parent_user_id", None):
+        return jsonify({"error": "Acces neautorizat."}), 403
+
+    payload = request.get_json(silent=True) or {}
+    code = (payload.get("code") or "").strip()
+    slug = (payload.get("slug") or "").strip()
+
+    if not code:
+        return jsonify({"error": "Cod lipsă."}), 400
+
+    sac = ScopedAccessCode.query.filter_by(code=code, created_by_user_id=current_user.id).first_or_404()
+
+    if not slug:
+        sac.custom_slug = None
+    else:
+        import re as _re
+        if not _re.fullmatch(r"[a-z0-9-]{3,64}", slug):
+            return jsonify({"error": "Slug invalid. Folosiți doar litere mici, cifre și liniuță (-), 3-64 caractere."}), 400
+        existing = ScopedAccessCode.query.filter(ScopedAccessCode.custom_slug == slug, ScopedAccessCode.id != sac.id).first()
+        if existing:
+            return jsonify({"error": "Acest alias este deja folosit."}), 409
+        sac.custom_slug = slug
+
+    try:
+        db.session.commit()
+        return jsonify({
+            "ok": True,
+            "custom_slug": sac.custom_slug,
+            "slug_url": url_for("public_permissions_view_slug", slug=sac.custom_slug, _external=True) if sac.custom_slug else None
+        })
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({"error": f"Eroare la setare alias: {e}"}), 500
+
+
+@app.route("/permissions/api/get_slug", methods=["GET"], endpoint="permissions_get_public_slug")
+@login_required
+def permissions_get_public_slug():
+    if current_user.role != "gradat" or getattr(current_user, "parent_user_id", None):
+        return jsonify({"error": "Acces neautorizat."}), 403
+
+    code = (request.args.get("code") or "").strip()
+    if not code:
+        return jsonify({"error": "Cod lipsă."}), 400
+
+    sac = ScopedAccessCode.query.filter_by(code=code, created_by_user_id=current_user.id).first_or_404()
+    return jsonify({
+        "code": sac.code,
+        "custom_slug": sac.custom_slug,
+        "slug_url": url_for("public_permissions_view_slug", slug=sac.custom_slug, _external=True) if sac.custom_slug else None
+    })
+
+
+@app.route("/public/permissions/<code>", methods=["GET"], endpoint="public_permissions_view_code")
+def public_permissions_view_code(code):
+    """
+    Pagina publică (read-only) pentru clasamentul la Permisii.
+    Link-ul este generat de gradat și poate fi distribuit oricui.
+    """
+    now_utc = datetime.now(timezone.utc)
+    sac = ScopedAccessCode.query.filter_by(code=code, is_active=True).first()
+    if not sac or sac.expires_at <= now_utc:
+        return "Link invalid sau expirat.", 404
+
+    gradat_user = db.session.get(User, sac.created_by_user_id)
+    if not gradat_user:
+        return "Utilizatorul asociat acestui link nu mai există.", 404
+
+    # Construim clasamentul: număr total de permisii aprobate per student
+    # Excludem gradații/personal (similar cu voluntariatul): is_platoon_graded_duty, assigned_graded_platoon, pluton '0'
+    count_expr = func.count(Permission.id).label("perm_count")
+    results = (
+        db.session.query(Student, count_expr)
+        .outerjoin(
+            Permission,
+            and_(Permission.student_id == Student.id, Permission.status == "Aprobată"),
+        )
+        .filter(
+            Student.created_by_user_id == gradat_user.id,
+            Student.is_platoon_graded_duty == False,
+            or_(Student.assigned_graded_platoon == None, Student.assigned_graded_platoon == ""),
+            Student.pluton != "0",
+        )
+        .group_by(Student.id)
+        .order_by(sa.desc("perm_count"), Student.nume.asc(), Student.prenume.asc())
+        .all()
+    )
+
+    ranking = [{"student": s, "perm_count": pc or 0} for (s, pc) in results]
+
+    return render_template(
+        "public_permissions.html",
+        ranking=ranking,
+    )
+
+
+@app.route("/public/p/<slug>", methods=["GET"], endpoint="public_permissions_view_slug")
+def public_permissions_view_slug(slug):
+    now_utc = datetime.now(timezone.utc)
+    sac = ScopedAccessCode.query.filter_by(custom_slug=slug, is_active=True).first()
+    if not sac or sac.expires_at <= now_utc:
+        return "Link invalid sau expirat.", 404
+    # Redirect to code-based URL to reuse logic
+    return redirect(url_for("public_permissions_view_code", code=sac.code))
+
+
 @app.route(
     "/volunteer/save_session",
     methods=["POST"],

--- a/templates/public_permissions.html
+++ b/templates/public_permissions.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block title %}Clasament Permisii (Public){% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+   <div class="d-flex justify-content-between align-items-center mb-4">
+        <h2><i class="fas fa-id-card-alt me-"></i>Clasament Permisii</h2>
+        <a href="{{ url_for('public_view_logout') }}" class="btn btn-sm btn-outline-secondary">
+            <i class="fas fa-sign-out-alt me-1"></i> Ieșire
+        </a>
+    </div>
+
+    <div class="alert alert-info" role="alert">
+        <i class="fas fa-info-circle me-2"></i>
+        Pagina este publică, doar pentru vizualizare. Clasamentul se bazează pe numărul total de permisii aprobate pentru fiecare student (excluzând gradații/personal).
+    </div>
+
+   


### PR DESCRIPTION
This PR introduces a public permissions ranking feature that allows users to view a leaderboard of approved permissions for students. The public link can be generated and managed by users with the 'gradat' role, providing visibility into who has the most and least permissions. Users can also set custom slugs for their links. The system ensures that only active and valid links are accessible. A new HTML template is included for displaying the rankings, which excludes graded personnel from the count.

---

> This pull request was co-created with Cosine Genie

Original Task: [test/pe0ka3wa2mpb](https://cosine.sh/21as2gnxjvhd/test/task/pe0ka3wa2mpb)
Author: rentfrancisc
