### PR TITLE
Fix CSRF Token Handling to Prevent Bad Request Errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,7 @@ from flask import (
 from flask_compress import Compress
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate  # Added for database migrations
-from flask_wtf.csrf import CSRFProtect
+from flask_wtf.csrf import CSRFProtect, generate_csrf
 from flask_caching import Cache
 from sqlalchemy.orm import joinedload
 import sqlalchemy as sa  # Adăugat pentru server_default=sa.text()
@@ -314,6 +314,15 @@ migrate = Migrate(app, db)  # Initialize Flask-Migrate
 
 # SECURITY: Enable CSRF Protection
 csrf = CSRFProtect(app)
+
+@app.context_processor
+def inject_csrf_token():
+    try:
+        return dict(csrf_token=generate_csrf)
+    except Exception:
+        # Fallback: provide empty token to avoid template errors; CSRF will still enforce on POST
+        return dict(csrf_token=lambda:_code "new"</)
+)
 
 # PERFORMANCE: Enable caching
 cache_config = {

--- a/templates/base.html
+++ b/templates/base.html
@@ -279,6 +279,53 @@
         })();
     </script>
 
+    <script>
+    (function() {
+        try {
+            var token = "{{ csrf_token() }}";
+            window.CSRF_TOKEN = token;
+            // Inject hidden CSRF field into all non-GET forms
+            document.addEventListener('DOMContentLoaded', function() {
+                try {
+                    document.querySelectorAll('form').forEach(function(form) {
+                        var method = (form.getAttribute('method') || 'GET').toUpperCase();
+                        if (method !== 'GET' && !form.querySelector('input[name="csrf_token"]')) {
+                            var inp = document.createElement('input');
+                            inp.type = 'hidden';
+                            inp.name = 'csrf_token';
+                            inp.value = token;
+                            form.appendChild(inp);
+                        }
+                    });
+                } catch (e) {}
+            });
+            // Patch fetch to include CSRF header for same-origin state-changing requests
+            var _fetch = window.fetch;
+            window.fetch = function(input, init) {
+                init = init || {};
+                var url = (typeof input === 'string') ? input : (input && input.url) || '';
+                var method = (init.method || 'GET').toUpperCase();
+                var isSameOrigin = true;
+                try {
+                    var u = new URL(url, window.location.origin);
+                    isSameOrigin = (u.origin === window.location.origin);
+                } catch (e) {}
+                if (isSameOrigin && method !== 'GET') {
+                    init.headers = init.headers || {};
+                    if (init.headers instanceof Headers) {
+                        init.headers.set('X-CSRFToken', token);
+                    } else if (Array.isArray(init.headers)) {
+                        init.headers.push(['X-CSRFToken', token]);
+                    } else {
+                        init.headers['X-CSRFToken'] = token;
+                    }
+                }
+                return _fetch(input, init);
+            };
+        } catch (e) {}
+    })();
+    </script>
+
     {% block scripts %}{% endblock %}
     {% block extra_js %}{% endblock %}
 </body>


### PR DESCRIPTION
This pull request addresses an issue related to the missing CSRF token that was causing 'Bad Request' errors when accessing the site. The changes include modifications to the `app.py` to correctly generate and inject the CSRF token into the context processor. Additionally, the `base.html` template has been updated to ensure that the CSRF token is included in all non-GET forms and that the fetch API is patched to automatically include the CSRF token for same-origin state-changing requests. These changes help to enhance security and improve user experience by preventing form submission errors.

---

> This pull request was co-created with Cosine Genie

Original Task: [test/cqsxowbartv0](https://cosine.sh/21as2gnxjvhd/test/task/cqsxowbartv0)
Author: rentfrancisc
