### PR TITLE
Improve Permissions Ranking Display and Navigation

### DIFF
--- a/templates/nav_links.html
+++ b/templates/nav_links.html
@@ -10,6 +10,7 @@
         <li><a href="{{ url_for('list_services') }}">Servicii</a></li>
         <li><a href="{{ url_for('calendar_page') }}">Calendar</a></li>
         <li><a href="{{ url_for('calendar_links_manage') }}">Linkuri Calendar</a></li>
+        <li><a href="{{ url_for('permissions_links_manage') }}">Linkuri Clasament Permisii</a></li>
         <li><a href="{{ url_for('volunteer_home') }}">Voluntariat</a></li>
         <li><a href="{{ url_for('presence_report') }}">Raport Prezență</a></li>
     {% elif current_user.role == 'admin' %}

--- a/templates/public_permissions.html
+++ b/templates/public_permissions.html
@@ -23,30 +23,30 @@
         </div>
         <div class="card-body p-0">
             <div class="table-responsive">
-                <table class="table table-striped table-hover align-middle mb-0">
+                <table class="table table-sm table-striped table-hover align-middle mb-0 table-compact">
                     <thead class="table-light">
                         <tr>
                             <th style="width: 64px;">#</th>
                             <th>Student</th>
-                            <th style="width: 140px;">Pluton</th>
-                            <th style="width: 140px;">Companie</th>
-                            <th style="width: 200px;">Grad Militar</th>
-                            <th style="width: 160px;" class="text-end">Total Permisii</th>
+                            <th style="width: 160px;" class="text-center">Total Permisii</th>
+                            <th style="width: 120px;" class="text-end">Detalii</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for item in ranking %}
                         <tr>
                             <td class="text-muted">{{ loop.index }}</td>
-                            <td>
-                                <a href="{{ url_for('public_student_profile', student_id=item.student.id, code=access_code) }}">
-                                    {{ item.student.nume }} {{ item.student.prenume }}
+                            <td class="text-truncate" style="max-width: 220px;">
+                                <strong>{{ item.student.nume }} {{ item.student.prenume }}</strong>
+                            </td>
+                            <td class="text-center">
+                                <span class="badge bg-primary rounded-pill">{{ item.perm_count }}</span>
+                            </td>
+                            <td class="text-end">
+                                <a href="{{ url_for('public_student_profile', student_id=item.student.id, code=access_code) }}" class="btn btn-sm btn-outline-info">
+                                    <i class="fas fa-info-circle me-1"></i> Detalii
                                 </a>
                             </td>
-                            <td>{{ item.student.pluton or '—' }}</td>
-                            <td>{{ item.student.companie or '—' }}</td>
-                            <td>{{ item.student.grad_militar or '—' }}</td>
-                            <td class="text-end"><strong>{{ item.perm_count }}</strong></td>
                         </tr>
                         {% endfor %}
                     </tbody>


### PR DESCRIPTION
This PR enhances the display of the public permissions ranking by making it more compact and organized for mobile devices. It removes unnecessary columns such as Pluton, Companie, and Grad Militar, leaving only the Student's name and Total Permisii, alongside a new button for viewing detailed permission information. Additionally, it fixes the navigation by including a link to manage custom links for the permissions ranking.

---

> This pull request was co-created with Cosine Genie

Original Task: [test/bfna7rkmht78](https://cosine.sh/21as2gnxjvhd/test/task/bfna7rkmht78)
Author: rentfrancisc
