### PR TITLE
Fix expired leaves display and enhance dashboard statistics

### DIFF
--- a/templates/gradat_dashboard.html
+++ b/templates/gradat_dashboard.html
@@ -122,6 +122,28 @@ Absenti motivat:
                              <p class="mb-1"><i class="fas fa-hands-helping text-primary me-2"></i>Studenți cu peste 10p voluntariat: <strong>{{ students_with_high_points }}</strong></p>
                              <p class="mb-1"><i class="fas fa-shield-alt text-info me-2"></i>Total servicii planificate: <strong>{{ total_services_count }}</strong></p>
                              <p class="mb-1"><i class="fas fa-calendar-check text-success me-2"></i>Servicii în următoarele 7 zile: <strong>{{ upcoming_services_count }}</strong></p>
+
+                             <hr class="my-2">
+                             <h6 class="card-title"><i class="fas fa-chart-line me-2"></i>Azi (rezumat învoiri)</h6>
+                             <p class="mb-1">
+                                <i class="fas fa-road text-secondary me-2"></i>Permisii de azi:
+                                <strong>{{ permissions_today_count }}</strong>
+                                <a href="{{ url_for('list_permissions') }}" class="small ms-2">vezi</a>
+                             </p>
+                             <p class="mb-1">
+                                <i class="fas fa-walking text-secondary me-2"></i>Învoiri zilnice de azi:
+                                <strong>{{ daily_leaves_today_count }}</strong>
+                                <a href="{{ url_for('list_daily_leaves') }}" class="small ms-2">vezi</a>
+                             </p>
+                             <p class="mb-1">
+                                <i class="fas fa-church text-secondary me-2"></i>Învoiri weekend (active azi):
+                                <strong>{{ weekend_leaves_today_count }}</strong>
+                                <a href="{{ url_for('list_weekend_leaves') }}" class="small ms-2">vezi</a>
+                             </p>
+                             <p class="mb-1">
+                                <i class="fas fa-list text-secondary me-2"></i>Total învoiri azi:
+                                <strong>{{ permissions_today_count + daily_leaves_today_count + weekend_leaves_today_count }}</strong>
+                             </p>
                         </div>
                         <div class="col-md-6">
                             <h6 class="card-title"><i class="fas fa-shield-alt text-info me-2"></i>Serviciile de azi (plutonul meu)</h6>

--- a/templates/list_daily_leaves.html
+++ b/templates/list_daily_leaves.html
@@ -72,8 +72,23 @@
 
 
     {% macro render_daily_leaves_table(leaves, table_title) %}
-        {% if leaves %}
-        <h4 class="mt-4">{{ table_title }} ({{ leaves|length }})</h4>
+        {# Pre-calculează numărul de înregistrări relevante pentru tabel (filtrate corect) #}
+        {% set ns = namespace(count=0) %}
+        {% for leave in leaves %}
+            {% set include_row = (
+                table_title.startswith('Învoiri Active') and leave.is_active()
+            ) or (
+                table_title.startswith('Învoiri Viitoare') and leave.is_upcoming
+            ) or (
+                table_title.startswith('Învoiri Trecute/Anulate') and (leave.is_past or leave.status == 'Anulată')
+            ) %}
+            {% if include_row %}
+                {% set ns.count = ns.count + 1 %}
+            {% endif %}
+        {% endfor %}
+
+        {% if ns.count > 0 %}
+        <h4 class="mt-4">{{ table_title }} ({{ ns.count }})</h4>
         <div class="table-responsive shadow-sm"> <!-- Added shadow-sm -->
             <table class="table table-striped table-hover table-sm">
                 <thead> <!-- Am eliminat clasa table-dark -->
@@ -90,56 +105,64 @@
                 </thead>
                 <tbody>
                     {% for leave in leaves %}
-                    <tr>
-                        <td>{{ leave.student.nume }} {{ leave.student.prenume }}</td>
-                        <td>{{ leave.leave_date|localdate('%d-%m-%y (%a)') }}</td>
-                        <td>{{ leave.start_time|localtime('%H:%M') }}</td>
-                        <td>{{ leave.end_time|localtime('%H:%M') }} {% if leave.end_datetime.date() > leave.leave_date %}<span class="badge bg-secondary">ziua următoare</span>{% endif %}</td>
-                        <td><span class="badge bg-secondary">{{ leave.leave_type_display }}</span></td>
-                        <td>{{ leave.reason if leave.reason else '-' }}</td>
-                        <td>
-                            {% if leave.status == 'Aprobată' %}
-                                {% if leave.is_active() %}
-                                    <span class="badge bg-secondary">Activă</span>
-                                {% elif leave.is_upcoming %}
-                                    <span class="badge bg-secondary">Urmează</span>
+                        {% set include_row = (
+                            table_title.startswith('Învoiri Active') and leave.is_active()
+                        ) or (
+                            table_title.startswith('Învoiri Viitoare') and leave.is_upcoming
+                        ) or (
+                            table_title.startswith('Învoiri Trecute/Anulate') and (leave.is_past or leave.status == 'Anulată')
+                        ) %}
+                        {% if include_row %}
+                        <tr>
+                            <td>{{ leave.student.nume }} {{ leave.student.prenume }}</td>
+                            <td>{{ leave.leave_date|localdate('%d-%m-%y (%a)') }}</td>
+                            <td>{{ leave.start_time|localtime('%H:%M') }}</td>
+                            <td>{{ leave.end_time|localtime('%H:%M') }} {% if leave.end_datetime.date() > leave.leave_date %}<span class="badge bg-secondary">ziua următoare</span>{% endif %}</td>
+                            <td><span class="badge bg-secondary">{{ leave.leave_type_display }}</span></td>
+                            <td>{{ leave.reason if leave.reason else '-' }}</td>
+                            <td>
+                                {% if leave.status == 'Aprobată' %}
+                                    {% if leave.is_active() %}
+                                        <span class="badge bg-secondary">Activă</span>
+                                    {% elif leave.is_upcoming %}
+                                        <span class="badge bg-secondary">Urmează</span>
+                                    {% else %}
+                                        <span class="badge bg-secondary">Expirată</span>
+                                    {% endif %}
+                                {% elif leave.status == 'Anulată' %}
+                                    <span class="badge bg-secondary">Anulată</span>
                                 {% else %}
-                                    <span class="badge bg-secondary">Expirată</span>
+                                    <span class="badge bg-secondary">{{ leave.status }}</span>
                                 {% endif %}
-                            {% elif leave.status == 'Anulată' %}
-                                <span class="badge bg-secondary">Anulată</span>
-                            {% else %}
-                                <span class="badge bg-secondary">{{ leave.status }}</span>
-                            {% endif %}
-                        </td>
-                        <td>
-                            <a href="{{ url_for('add_edit_daily_leave', leave_id=leave.id) }}" class="btn btn-sm btn-warning me-1 py-0 px-1" title="Editare Învoire Zilnică">
-                                <i class="fas fa-edit icon-rotate-hover"></i>
-                            </a>
-                            {% if leave.status == 'Aprobată' and (leave.is_active() or leave.is_upcoming) %}
-                            <form method="POST" action="{{ url_for('cancel_daily_leave', leave_id=leave.id) }}" class="d-inline" onsubmit="return confirm('Ești sigur că vrei să anulezi această învoire?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" title="Anulează Învoirea">
-                                    <i class="fas fa-times-circle icon-rotate-hover"></i>
-                                </button>
-                            </form>
-                            {% elif leave.status != 'Anulată' and leave.is_past %}
-                                <span class="text-muted fst-italic small">Expirată</span>
-                            {% elif leave.status == 'Anulată' %}
-                                <span class="text-muted fst-italic small">Anulată</span>
-                            {% endif %}
-                            {# Buton de ștergere permanentă #}
-                            <form method="POST" action="{{ url_for('delete_daily_leave', leave_id=leave.id) }}" class="d-inline" onsubmit="return confirm('Ești sigur că vrei să ȘTERGI PERMANENT această învoire zilnică? Această acțiune nu poate fi anulată.');">
-                                <button type="submit" class="btn btn-sm btn-danger py-0 px-1 ms-1" title="Șterge Învoirea Zilnică Permanent">
-                                    <i class="fas fa-trash-alt icon-rotate-hover"></i>
-                                </button>
-                            </form>
-                        </td>
-                    </tr>
+                            </td>
+                            <td>
+                                <a href="{{ url_for('add_edit_daily_leave', leave_id=leave.id) }}" class="btn btn-sm btn-warning me-1 py-0 px-1" title="Editare Învoire Zilnică">
+                                    <i class="fas fa-edit icon-rotate-hover"></i>
+                                </a>
+                                {% if leave.status == 'Aprobată' and (leave.is_active() or leave.is_upcoming) %}
+                                <form method="POST" action="{{ url_for('cancel_daily_leave', leave_id=leave.id) }}" class="d-inline" onsubmit="return confirm('Ești sigur că vrei să anulezi această învoire?');">
+                                    <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" title="Anulează Învoirea">
+                                        <i class="fas fa-times-circle icon-rotate-hover"></i>
+                                    </button>
+                                </form>
+                                {% elif leave.status != 'Anulată' and leave.is_past %}
+                                    <span class="text-muted fst-italic small">Expirată</span>
+                                {% elif leave.status == 'Anulată' %}
+                                    <span class="text-muted fst-italic small">Anulată</span>
+                                {% endif %}
+                                {# Buton de ștergere permanentă #}
+                                <form method="POST" action="{{ url_for('delete_daily_leave', leave_id=leave.id) }}" class="d-inline" onsubmit="return confirm('Ești sigur că vrei să ȘTERGI PERMANENT această învoire zilnică? Această acțiune nu poate fi anulată.');">
+                                    <button type="submit" class="btn btn-sm btn-danger py-0 px-1 ms-1" title="Șterge Învoirea Zilnică Permanent">
+                                        <i class="fas fa-trash-alt icon-rotate-hover"></i>
+                                    </button>
+                                </form>
+                            </td>
+                        </tr>
+                        {% endif %}
                     {% endfor %}
                 </tbody>
             </table>
         </div>
-        {# Am eliminat clauza else pentru a gestiona mesajul global #}
         {% endif %}
     {% endmacro %}
 


### PR DESCRIPTION
This pull request addresses two main issues: it prevents expired leave records from appearing on active leave lists, and enhances the dashboard by adding summary statistics for today's permissions and daily leaves. 

Changes made include:
- Updated the logic in `list_daily_leaves.html` to accurately calculate and display only relevant active and past leaves.
- Modified `gradat_dashboard.html` to include new summary sections displaying today's permissions, daily leaves, and active weekend leaves, offering a clearer overview of current statuses at a glance.

---

> This pull request was co-created with Cosine Genie

Original Task: [test/e6ewpcnm7szp](https://cosine.sh/21as2gnxjvhd/test/task/e6ewpcnm7szp)
Author: rentfrancisc
